### PR TITLE
Radeon module info: Don't parse error messages.

### DIFF
--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -266,6 +266,10 @@ void radeon_profile::getModuleInfo() {
 
     for (int i =0; i < modInfo.count(); i++) {
         if (modInfo[i].contains(":")) {
+            // show nothing in case of an error
+            if (modInfo[i].startsWith("modinfo: ERROR: ")) {
+                continue;
+            }
             // read module param name and description from modinfo command
             QString modName = modInfo[i].split(":",QString::SkipEmptyParts)[0],
                     modDesc = modInfo[i].split(":",QString::SkipEmptyParts)[1],


### PR DESCRIPTION
in case of an error, like the radeon module being buid into the kernel, the info shows:
Option  | Value   | Description
modinfo | unknown | ERROR

Now it shows nothing instead.

Signed-off-by: V10lator v10lator@myway.de
