### PR TITLE
Fixed bug that prevented the app from opening

### DIFF
--- a/radeon-profile/extra/radeon-profile.desktop
+++ b/radeon-profile/extra/radeon-profile.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Radeon Profile
 Comment=Monitor Radeon GPU parameters and switch power profiles
-Exec=sudo radeon-profile
+Exec=gksudo radeon-profile
 Icon=radeon-profile
 Terminal=false
 Type=Application

--- a/radeon-profile/extra/radeon-profile.desktop
+++ b/radeon-profile/extra/radeon-profile.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Radeon Profile
 Comment=Monitor Radeon GPU parameters and switch power profiles
-Exec=gksudo radeon-profile
+Exec=radeon-profile
 Icon=radeon-profile
 Terminal=false
 Type=Application


### PR DESCRIPTION
On Gnome 3.18.3, opening the desktop entry for radeon-profile didn't start anything.
I tried rebooting but nothing changed. I checked the journal and noticed this log:
`sudo: no tty present and no askpass program specified`
I checked the .desktop file and edited the Exec to `gksudo`, now the program starts correctly.

As a side note, when this pull request is merged `gksudo` should be added to the the dependencies of the PKGBUILD