### PR TITLE
UI fixes, cleanup

### DIFF
--- a/radeon-profile/dfglrx.cpp
+++ b/radeon-profile/dfglrx.cpp
@@ -65,6 +65,7 @@ globalStuff::driverFeatures dFglrx::figureOutDriverFeatures() {
     features.memClockAvailable = true;
     features.temperatureAvailable = true;
     features.pwmAvailable = false;
+    features.overClockAvailable = false;
     return features;
 }
 

--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -337,7 +337,7 @@ QString dXorg::findSysfsHwmonForGPU() {
     return "";
 }
 
-QStringList dXorg::getGLXInfo(QString gpuName, QProcessEnvironment env) {
+QStringList dXorg::getGLXInfo(QProcessEnvironment env) {
     return globalStuff::grabSystemInfo("glxinfo",env).filter(QRegExp("direct|OpenGL.+:.+"));
 }
 
@@ -644,7 +644,6 @@ bool dXorg::overClock(const int percentage){
     else // Overclock requires root access to sysfs
         return false;
 
-    qDebug() << "Overclocked card by" << percentage << "%";
     return true;
 }
 

--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -130,10 +130,10 @@ QString dXorg::getClocksRawData(bool resolvingGpuFeatures) {
 
         // fist call, so notihing is in sharedmem and we need to wait for data
         // because we need correctly figure out what is available
-        // see: https://stackoverflow.com/questions/3752742/how-do-i-create-a-pause-wait-function-using-qt
+        // see: https://stackoverflow.com/a/11487434/2347196
         if (resolvingGpuFeatures) {
             QTime delayTime = QTime::currentTime().addMSecs(1000);
-            while (QTime::currentTime() < delayTime);
+            while (QTime::currentTime() < delayTime)
                 QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
         }
 

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -58,8 +58,16 @@ private:
     static QSharedMemory sharedMem;
 
     static struct driverFilePaths {
-    QString powerMethodFilePath, profilePath, dpmStateFilePath ,
-            clocksPath , forcePowerLevelFilePath , sysfsHwmonTempPath, moduleParamsPath, pwmEnablePath, pwmSpeedPath, pwmMaxSpeedPath;
+        QString powerMethodFilePath,
+            profilePath,
+            dpmStateFilePath,
+            clocksPath,
+            forcePowerLevelFilePath,
+            sysfsHwmonTempPath,
+            moduleParamsPath,
+            pwmEnablePath,
+            pwmSpeedPath,
+            pwmMaxSpeedPath;
     } filePaths;
     static int sensorsGPUtempIndex;
     static dXorg::tempSensor currentTempSensor;

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -44,6 +44,15 @@ public:
     static bool daemonConnected();
     static globalStuff::gpuClocksStruct getFeaturesFallback();
 
+    /**
+     * @brief overClock Overclocks the GPU
+     * @param percent Overclock percentage [0-20]
+     * @return Success
+     */
+    static bool overClock(int percentage);
+
+    static void resetOverClock();
+
 
 private:
     enum tempSensor {
@@ -67,7 +76,8 @@ private:
             moduleParamsPath,
             pwmEnablePath,
             pwmSpeedPath,
-            pwmMaxSpeedPath;
+            pwmMaxSpeedPath,
+            overDrivePath;
     } filePaths;
     static int sensorsGPUtempIndex;
     static dXorg::tempSensor currentTempSensor;

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -25,7 +25,7 @@ public:
     static globalStuff::gpuClocksStruct getClocks(const QString &data);
     static QString getClocksRawData(bool forFeatures = false);
     static float getTemperature();
-    static QStringList getGLXInfo(QString gpuName, QProcessEnvironment env);
+    static QStringList getGLXInfo(QProcessEnvironment env);
     static QList<QTreeWidgetItem *> getModuleInfo();
     static QString getCurrentPowerLevel();
     static QString getCurrentPowerProfile();

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -77,6 +77,7 @@
 #define label_howToEdit QObject::tr("This step already exists. To edit it double click it")
 #define label_cantDeleteThisItem QObject::tr("You can't delete the first and the last item")
 #define label_cantEditThisItem QObject::tr("You can't edit the first and the last item")
+#define label_overclockFailed QObject::tr("An error occurred, overclock failed")
 
 // execbin.cpp
 #define label_processRunning QObject::tr("Process state: running")

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -30,6 +30,7 @@
 #define file_powerProfile "power_profile"
 #define file_powerDpmState "power_dpm_state"
 #define file_powerDpmForcePerformanceLevel "power_dpm_force_performance_level"
+#define file_overclockLevel "pp_sclk_od"
 
 #define label_currentPowerLevel QObject::tr("Power level")
 #define label_currentGPUClock QObject::tr("GPU clock")
@@ -73,6 +74,9 @@
 #define label_selectProfile QObject::tr("Select new power profile")
 #define label_profileSelection QObject::tr("Profile selection")
 #define label_processStillRunning QObject::tr("Process is still running. Close tab?")
+#define label_howToEdit QObject::tr("This step already exists. To edit it double click it")
+#define label_cantDeleteThisItem QObject::tr("You can't delete the first and the last item")
+#define label_cantEditThisItem QObject::tr("You can't edit the first and the last item")
 
 // execbin.cpp
 #define label_processRunning QObject::tr("Process state: running")
@@ -151,6 +155,9 @@
 #define format_stats_memVolt QObject::tr("%nmV)", NULL, device.gpuClocksData.memVolt)
 
 #define logDateFormat "yyyy-MM-dd_hh-mm-ss"
+
+#define appVersion 20160515
+#define format_version QObject::tr("Version %n", NULL, appVersion)
 
 
 class globalStuff {
@@ -234,7 +241,8 @@ public:
             coreVoltAvailable,
             memVoltAvailable,
             temperatureAvailable,
-            pwmAvailable;
+            pwmAvailable,
+            overClockAvailable;
         globalStuff::powerMethod pm;
         int pwmMaxSpeed;
 
@@ -245,7 +253,8 @@ public:
                     coreVoltAvailable =
                     memVoltAvailable =
                     temperatureAvailable =
-                    pwmAvailable = false;
+                    pwmAvailable =
+                    overClockAvailable = false;
             pm = PM_UNKNOWN;
             pwmMaxSpeed = 0;
         }

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -100,6 +100,7 @@
 #define label_askRunEnd QObject::tr("\"?")
 
 // gpu.cpp
+#define label_unknown QObject::tr ("Unknown")
 #define label_resolution QObject::tr("Resolution")
 #define label_minimumRes QObject::tr("Minimum resolution")
 #define label_maximumRes QObject::tr("Maximum resolution")
@@ -129,6 +130,7 @@
 #define format_monDiagonal QObject::tr("(%n inches)", NULL, diagonal)
 #define format_outputConnected QObject::tr("%n connected, ", NULL, screenConnectedOutputs)
 #define format_outputActive QObject::tr("%n active", NULL, screenActiveOutputs)
+#define label_noInfo QObject::tr("No info")
 
 // radeon_profile.cpp
 #define label_backToProfiles QObject::tr("Back to profiles") // As "return to profiles"
@@ -203,13 +205,13 @@ public:
         gpuClocksStruct() { }
 
         gpuClocksStruct(int _coreClk, int _memClk, int _coreVolt, int _memVolt, int _uvdCClk, int _uvdDclk, char _pwrLevel ) {
-            coreClk = _coreClk,
-                    memClk = _memClk,
-                    coreVolt = _coreVolt,
-                    memVolt = _memVolt,
-                    uvdCClk = _uvdCClk,
-                    uvdDClk = _uvdDclk,
-                    powerLevel = _pwrLevel;
+            coreClk = _coreClk;
+            memClk = _memClk;
+            coreVolt = _coreVolt;
+            memVolt = _memVolt;
+            uvdCClk = _uvdCClk;
+            uvdDClk = _uvdDclk;
+            powerLevel = _pwrLevel;
         }
 
         // initialize empty struct, so when we pass -1, only values that != -1 will show
@@ -226,12 +228,24 @@ public:
     // structure which holds what can be display on ui and on its base
     // we enable ui elements
     struct driverFeatures {
-        bool canChangeProfile, coreClockAvailable, memClockAvailable, coreVoltAvailable, memVoltAvailable, temperatureAvailable, pwmAvailable;
+        bool canChangeProfile,
+            coreClockAvailable,
+            memClockAvailable,
+            coreVoltAvailable,
+            memVoltAvailable,
+            temperatureAvailable,
+            pwmAvailable;
         globalStuff::powerMethod pm;
         int pwmMaxSpeed;
 
         driverFeatures() {
-            canChangeProfile = coreClockAvailable = memClockAvailable = coreVoltAvailable = memVoltAvailable = temperatureAvailable= pwmAvailable = false;
+            canChangeProfile =
+                    coreClockAvailable =
+                    memClockAvailable =
+                    coreVoltAvailable =
+                    memVoltAvailable =
+                    temperatureAvailable =
+                    pwmAvailable = false;
             pm = PM_UNKNOWN;
             pwmMaxSpeed = 0;
         }

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -860,3 +860,16 @@ void gpu::getPwmSpeed() {
         break;
     }
 }
+
+bool gpu::overclock(const int value){
+    if(features.overClockAvailable && (currentDriver == XORG))
+        return dXorg::overClock(value);
+
+    qWarning() << "Error overclocking: overclocking is not supported";
+    return false;
+}
+
+void gpu::resetOverclock(){
+    if(features.overClockAvailable && (currentDriver == XORG))
+        dXorg::resetOverClock();
+}

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -768,7 +768,7 @@ QStringList gpu::getGLXInfo(QString gpuName) const {
 
     switch (currentDriver) {
     case XORG:
-        data << dXorg::getGLXInfo(gpuName, env);
+        data << dXorg::getGLXInfo(env);
         break;
     case FGLRX:
         data << dFglrx::getGLXInfo();

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -81,7 +81,7 @@ QStringList gpu::initialize(bool skipDetectDriver) {
         f.pm = globalStuff::PM_UNKNOWN;
         f.canChangeProfile = f.temperatureAvailable = f.coreVoltAvailable = f.coreClockAvailable = false;
         features = f;
-        gpuList << "unknown";
+        gpuList << label_unknown;
     }
     }
     return gpuList;
@@ -744,7 +744,7 @@ QList<QTreeWidgetItem *> gpu::getModuleInfo() const {
         break;
     case FGLRX:
     case DRIVER_UNKNOWN: {
-        list.append(new QTreeWidgetItem(QStringList() <<"err"));
+        list.append(new QTreeWidgetItem(QStringList() << label_noInfo));
     }
     }
 

--- a/radeon-profile/gpu.h
+++ b/radeon-profile/gpu.h
@@ -59,6 +59,8 @@ public:
     void reconfigureDaemon();
     bool daemonConnected();
 
+    bool overclock(int value);
+    void resetOverclock();
 
 private:
     driver currentDriver;

--- a/radeon-profile/gpu.h
+++ b/radeon-profile/gpu.h
@@ -18,8 +18,13 @@ public:
         XORG, FGLRX, DRIVER_UNKNOWN
     };
 
-    explicit gpu() { currentGpuIndex = 0;
-                   gpuTemeperatureData.current  = gpuTemeperatureData.max = gpuTemeperatureData.min = gpuTemeperatureData.sum = 0; }
+    explicit gpu() {
+        currentGpuIndex = 0;
+        gpuTemeperatureData.current =
+                gpuTemeperatureData.max =
+                gpuTemeperatureData.min =
+                gpuTemeperatureData.sum = 0;
+    }
 
     globalStuff::gpuClocksStruct gpuClocksData;
     globalStuff::gpuClocksStructString gpuClocksDataString;

--- a/radeon-profile/main.cpp
+++ b/radeon-profile/main.cpp
@@ -7,15 +7,6 @@ int main(int argc, char *argv[])
     QApplication a(argc, argv);
 
     QTranslator * translator = new QTranslator();
-    /* NOTE FOR PACKAGING
-     * In this folder are present translation files ( strings.*.ts )
-     * After editing the source code it is necessary to run "lupdate" in this folder (in QtCreator: Tools > External > Linguist > Update)
-     * Then these files can be edited with the Qt linguist
-     * When the translations are ready it is necessary to run "lrelease" in this folder (in QtCreator: Tools > External > Linguist > Release)
-     * This produces compiled translation files ( strings.*.qm )
-     * In order to be used these files need to be packaged together with the runnable
-     * These can be placed in "/usr/share/radeon-profile/" or in the same folder of the binary (useful for development)
-     */
     if(translator->load(QLocale(), "strings", ".", "/usr/share/radeon-profile") || translator->load(QLocale(), "strings", "."))
         a.installTranslator(translator);
     else

--- a/radeon-profile/radeon-profile.pro
+++ b/radeon-profile/radeon-profile.pro
@@ -50,6 +50,13 @@ RESOURCES += \
 # These are provided in libxrandr(Arch), libXrandr(RedHat,Fedora), libxrandr-dev(Debian,Ubuntu), libxrandr-devel(SUSE)
 LIBS += -lXrandr -lX11
 
+# NOTE FOR PACKAGING
+# In this folder are present translation files (strings.*.ts)
+# After editing a translatable string it is necessary to run "lupdate" in this folder (QtCreator: Tools > External > Linguist > Update)
+# Then these files can be edited with the Qt linguist
+# When the translations are ready it is necessary to run "lrelease" in this folder (QtCreator: Tools > External > Linguist > Release)
+# This produces compiled translation files (strings.*.qm), that need to be packaged together with the runnable
+# These can be placed in "/usr/share/radeon-profile/" or in the same folder of the binary (useful for development)
 TRANSLATIONS += strings.it.ts
 
 DISTFILES += strings.it.ts

--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -75,6 +75,9 @@ radeon_profile::radeon_profile(QStringList a,QWidget *parent) :
     ui->configGroups->setTabEnabled(2,device.daemonConnected());
     setupUiEnabledFeatures(device.features);
 
+    if(ui->cb_enableOverclock->isChecked() && ui->cb_overclockAtLaunch->isChecked())
+        ui->btn_applyOverclock->click();
+
     connectSignals();
 
     // timer init
@@ -196,6 +199,14 @@ void radeon_profile::setupUiEnabledFeatures(const globalStuff::driverFeatures &f
         ui->combo_pLevel->setEnabled(false);
         ui->combo_pProfile->addItems(QStringList() << profile_auto << profile_default << profile_high << profile_mid << profile_low);
     }
+
+    // ui->mainTabs->setTabEnabled(2,features.overClockAvailable);
+    // Overclock is still not tested (it will be fully available only with Linux 4.7/4.8), disable it in release mode
+#ifdef QT_DEBUG // TO BE REMOVED AFTER TESTING
+    ui->mainTabs->setTabEnabled(2,true);
+#else
+    ui->mainTabs->setTabEnabled(2,false);
+#endif
 }
 
 void radeon_profile::refreshGpuData() {

--- a/radeon-profile/radeon_profile.h
+++ b/radeon-profile/radeon_profile.h
@@ -131,6 +131,9 @@ private slots:
     void on_btn_removeFanStep_clicked();
     void on_list_fanSteps_itemDoubleClicked(QTreeWidgetItem *item, int column);
     void on_fanSpeedSlider_valueChanged(int value);
+    void on_cb_enableOverclock_toggled(bool enable);
+    void on_btn_applyOverclock_clicked();
+    void on_slider_overclock_valueChanged(int value);
 
 private:
     gpu device;

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -51,7 +51,7 @@
       <widget class="QLabel" name="label">
        <property name="geometry">
         <rect>
-         <x>20</x>
+         <x>30</x>
          <y>0</y>
          <width>60</width>
          <height>24</height>
@@ -73,9 +73,9 @@
       <widget class="QComboBox" name="combo_gpus">
        <property name="geometry">
         <rect>
-         <x>10</x>
+         <x>0</x>
          <y>25</y>
-         <width>80</width>
+         <width>120</width>
          <height>25</height>
         </rect>
        </property>
@@ -98,15 +98,15 @@
       <widget class="QComboBox" name="combo_pProfile">
        <property name="geometry">
         <rect>
-         <x>100</x>
+         <x>125</x>
          <y>0</y>
-         <width>150</width>
+         <width>125</width>
          <height>24</height>
         </rect>
        </property>
        <property name="minimumSize">
         <size>
-         <width>140</width>
+         <width>100</width>
          <height>24</height>
         </size>
        </property>
@@ -129,9 +129,9 @@
       <widget class="QComboBox" name="combo_pLevel">
        <property name="geometry">
         <rect>
-         <x>125</x>
+         <x>150</x>
          <y>25</y>
-         <width>125</width>
+         <width>100</width>
          <height>24</height>
         </rect>
        </property>
@@ -305,7 +305,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="Line" name="line_4">
+      <widget class="Line" name="line_clocks">
        <property name="geometry">
         <rect>
          <x>330</x>
@@ -395,7 +395,7 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="Line" name="line_5">
+      <widget class="Line" name="line_temp">
        <property name="geometry">
         <rect>
          <x>520</x>
@@ -408,7 +408,7 @@
         <enum>Qt::Vertical</enum>
        </property>
       </widget>
-      <widget class="Line" name="line_6">
+      <widget class="Line" name="line_volts">
        <property name="geometry">
         <rect>
          <x>400</x>
@@ -843,7 +843,7 @@
                <set>QAbstractItemView::NoEditTriggers</set>
               </property>
               <attribute name="headerDefaultSectionSize">
-               <number>100</number>
+               <number>125</number>
               </attribute>
               <attribute name="headerMinimumSectionSize">
                <number>50</number>

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -305,19 +305,6 @@
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
-      <widget class="Line" name="line_clocks">
-       <property name="geometry">
-        <rect>
-         <x>330</x>
-         <y>10</y>
-         <width>10</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
       <widget class="QLabel" name="l_cVolt">
        <property name="geometry">
         <rect>
@@ -393,32 +380,6 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-      <widget class="Line" name="line_temp">
-       <property name="geometry">
-        <rect>
-         <x>520</x>
-         <y>10</y>
-         <width>10</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-      </widget>
-      <widget class="Line" name="line_volts">
-       <property name="geometry">
-        <rect>
-         <x>400</x>
-         <y>10</y>
-         <width>10</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
        </property>
       </widget>
      </widget>
@@ -3204,6 +3165,264 @@
              <string>Reconfigure daemon</string>
             </property>
            </widget>
+          </widget>
+          <widget class="QWidget" name="tab_about">
+           <attribute name="title">
+            <string>About</string>
+           </attribute>
+           <layout class="QGridLayout" name="gridLayout_3">
+            <item row="0" column="0">
+             <layout class="QVBoxLayout" name="verticalLayout_16">
+              <item>
+               <spacer name="verticalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>766</width>
+                  <height>27</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_radeonProfile">
+                <property name="font">
+                 <font>
+                  <pointsize>18</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Radeon Profile</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_version">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::PlainText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_gitHubRepo">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Go to GitHub repository&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_issues">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Report an issue&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_gitHubRepo_daemon">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile-daemon&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Radeon profile daemon&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>766</width>
+                  <height>28</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_contributors">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Contributors:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_contributor1">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Marazmista&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_contributor2">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/Danysan1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Danysan1&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_contributor3">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/V10lator&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;V10lator&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_contributor4">
+                <property name="font">
+                 <font>
+                  <pointsize>12</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/pontostroy&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Pontostroy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="textFormat">
+                 <enum>Qt::RichText</enum>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="openExternalLinks">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>766</width>
+                  <height>27</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
           </widget>
          </widget>
         </item>

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -1130,6 +1130,194 @@
         </item>
        </layout>
       </widget>
+      <widget class="QWidget" name="overclockTab">
+       <attribute name="title">
+        <string>Overclock</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout_7">
+        <item row="0" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_13">
+          <item>
+           <spacer name="horizontalSpacer_5">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_17">
+            <item>
+             <widget class="QLabel" name="label_8">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Be careful! Overclock can harm your GPU, use it only if you know what you are doing!</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignHCenter|Qt::AlignTop</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <item alignment="Qt::AlignHCenter">
+               <widget class="QCheckBox" name="cb_enableOverclock">
+                <property name="text">
+                 <string>Enable overclock</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignHCenter">
+               <widget class="QCheckBox" name="cb_overclockAtLaunch">
+                <property name="text">
+                 <string>Apply at launch</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <item>
+               <widget class="QSlider" name="slider_overclock">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>400</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>500</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="maximum">
+                 <number>20</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                 <enum>QSlider::TicksBothSides</enum>
+                </property>
+                <property name="tickInterval">
+                 <number>1</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_overclockPercentage">
+                <property name="text">
+                 <string notr="true">20</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="label_19">
+                <property name="text">
+                 <string notr="true">%</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item alignment="Qt::AlignHCenter">
+             <widget class="QPushButton" name="btn_applyOverclock">
+              <property name="maximumSize">
+               <size>
+                <width>100</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Apply</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="fanTab">
        <attribute name="title">
         <string>Fan Control</string>

--- a/radeon-profile/settings.cpp
+++ b/radeon-profile/settings.cpp
@@ -189,33 +189,26 @@ void radeon_profile::loadFanProfiles() {
         if (steps.count() > 1) {
             for (int i = 1; i < steps.count(); ++i) {
                 QStringList pair = steps[i].split("#");
-                ui->list_fanSteps->addTopLevelItem(new QTreeWidgetItem(QStringList() << pair[0] << pair[1]));
-
-                fanSteps.append(fanStepPair(pair[0].toInt(),pair[1].toInt()));
-
-                ui->plotFanProfile->graph(0)->addData(pair[0].toInt(), pair[1].toInt());
+                addFanStep(pair[0].toInt(),pair[1].toInt(), true, true, false);
             }
 
             fsPath.close();
         }
     } else {
         //default profile if no file found
-        fanSteps.append(fanStepPair(0,20));
-        fanSteps.append(fanStepPair(65,100));
-        fanSteps.append(fanStepPair(90,100));
+        addFanStep(0,20,true, true, false);
+        addFanStep(65,100,true, true, false);
+        addFanStep(90,100, true, true, false);
 
-        for (short i = 0;  i < fanSteps.count(); ++i)
-            ui->list_fanSteps->addTopLevelItem(new QTreeWidgetItem(QStringList() << QString().setNum(fanSteps[i].temperature) <<  QString().setNum(fanSteps[i].speed)));
     }
 
-    makeFanProfileGraph(fanSteps);
 }
 
-void radeon_profile::makeFanProfileGraph(const QList<fanStepPair> &steps) {
+void radeon_profile::makeFanProfileGraph() {
     ui->plotFanProfile->graph(0)->clearData();
 
-    for (int i = 0; i < steps.count(); ++i)
-        ui->plotFanProfile->graph(0)->addData(steps[i].temperature,steps[i].speed);
+    for (int temperature : fanSteps.keys())
+        ui->plotFanProfile->graph(0)->addData(temperature, fanSteps.value(temperature));
 
     ui->plotFanProfile->replot();
 }
@@ -224,8 +217,8 @@ void radeon_profile::saveFanProfiles() {
     QFile fsPath(fanStepsPath);
     if (fsPath.open(QIODevice::WriteOnly)) {
         QString profile = "default|";
-        for (int i = 0; i < fanSteps.count(); ++i)
-            profile.append(QString().setNum(fanSteps[i].temperature)+ "#" + QString().setNum(fanSteps[i].speed)  + "|");
+        for (int temperature : fanSteps.keys())
+            profile.append(QString::number(temperature)+ "#" + QString::number(fanSteps.value(temperature))  + "|");
 
         fsPath.write(profile.toLatin1());
         fsPath.close();

--- a/radeon-profile/settings.cpp
+++ b/radeon-profile/settings.cpp
@@ -41,6 +41,10 @@ void radeon_profile::saveConfig() {
     settings.setValue("daemonAutoRefresh",ui->cb_daemonAutoRefresh->isChecked());
     settings.setValue("fanSpeedSlider",ui->fanSpeedSlider->value());
 
+    settings.setValue("overclockEnabled", ui->cb_enableOverclock->isChecked());
+    settings.setValue("overclockAtLaunch", ui->cb_overclockAtLaunch->isChecked());
+    settings.setValue("overclockValue", ui->slider_overclock->value());
+
     // Graph settings
     settings.setValue("graphLineThickness",ui->spin_lineThick->value());
     settings.setValue("graphTempBackground",ui->graphColorsList->topLevelItem(TEMP_BG)->backgroundColor(1));
@@ -119,6 +123,10 @@ void radeon_profile::loadConfig() {
     ui->cb_showFreqGraph->setChecked(settings.value("showFreqGraphOnStart",true).toBool());
     ui->cb_showVoltsGraph->setChecked(settings.value("showVoltsGraphOnStart",false).toBool());
     ui->cb_execSysEnv->setChecked(settings.value("appendSysEnv",true).toBool());
+
+    ui->cb_enableOverclock->setChecked(settings.value("overclockEnabled",false).toBool());
+    ui->cb_overclockAtLaunch->setChecked(settings.value("overclockAtLaunch",false).toBool());
+    ui->slider_overclock->setValue(settings.value("overclockValue",0).toInt());
 
     // apply some settings to ui on start //
     if (ui->cb_saveWindowGeometry->isChecked())

--- a/radeon-profile/strings.it.ts
+++ b/radeon-profile/strings.it.ts
@@ -4,17 +4,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="globalStuff.h" line="108"/>
+        <location filename="globalStuff.h" line="109"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="109"/>
+        <location filename="globalStuff.h" line="110"/>
         <source>Minimum resolution</source>
         <translation>Risoluzione minima</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="110"/>
+        <location filename="globalStuff.h" line="111"/>
         <source>Maximum resolution</source>
         <translation>Risoluzione massima</translation>
     </message>
@@ -59,187 +59,187 @@
         <translation>Temperatura della GPU</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="137"/>
+        <location filename="globalStuff.h" line="138"/>
         <source>No info</source>
         <translation>Nessuna info</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="140"/>
+        <location filename="globalStuff.h" line="141"/>
         <source>Back to profiles</source>
         <translation>Ritorna ai profili</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="141"/>
+        <location filename="globalStuff.h" line="142"/>
         <source>Can&apos;t read data</source>
         <translation>Impossibile leggere i dati</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="142"/>
+        <location filename="globalStuff.h" line="143"/>
         <source>You need debugfs mounted and either root rights or the daemon running</source>
         <translation>È necessario che debugfs sia montato e che il demone sia attivo (o che il programma venga eseguito come root)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="90"/>
+        <location filename="globalStuff.h" line="91"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="91"/>
+        <location filename="globalStuff.h" line="92"/>
         <source>Profile name can&apos;t be empty!</source>
         <translation>Il nome del profilo non può essere vuoto!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="92"/>
+        <location filename="globalStuff.h" line="93"/>
         <source>No binary is selected!</source>
         <translation>Nessun eseguibile selezionato!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="93"/>
+        <location filename="globalStuff.h" line="94"/>
         <source>Binary not found in /usr/bin: </source>
         <translation>Eseguibile non trovato in /usr/bin: </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="94"/>
+        <location filename="globalStuff.h" line="95"/>
         <source>Enter value</source>
         <translation>Inserisci valore</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="95"/>
+        <location filename="globalStuff.h" line="96"/>
         <source>Enter valid value for </source>
         <translation>Inserisci un valore valido per </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="96"/>
+        <location filename="globalStuff.h" line="97"/>
         <source>Question</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="98"/>
+        <location filename="globalStuff.h" line="99"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="97"/>
+        <location filename="globalStuff.h" line="98"/>
         <source>Remove this item?</source>
         <translation>Rimuovere questo elemento?</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="99"/>
+        <location filename="globalStuff.h" line="100"/>
         <source>Select binary</source>
         <translation>Seleziona un eseguibile</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="100"/>
+        <location filename="globalStuff.h" line="101"/>
         <source>Select log file</source>
         <translation>Seleziona un file di log</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="101"/>
+        <location filename="globalStuff.h" line="102"/>
         <source>Can&apos;t run something that not exists!</source>
         <translation>Non posso eseguire qualcosa che non esiste!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="102"/>
+        <location filename="globalStuff.h" line="103"/>
         <source>Run</source>
         <translation>Esegui</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="103"/>
+        <location filename="globalStuff.h" line="104"/>
         <source>Run: &quot;</source>
         <translation>Eseguire &quot;</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="104"/>
+        <location filename="globalStuff.h" line="105"/>
         <source>&quot;?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="107"/>
+        <location filename="globalStuff.h" line="108"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="111"/>
+        <location filename="globalStuff.h" line="112"/>
         <source>Virtual size</source>
         <translation>Dimensione virtuale</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="112"/>
+        <location filename="globalStuff.h" line="113"/>
         <source>Outputs</source>
         <translation>Connessioni</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="113"/>
+        <location filename="globalStuff.h" line="114"/>
         <source>Active</source>
         <translation>Attivo</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="114"/>
+        <location filename="globalStuff.h" line="115"/>
         <source> Hz vertical, </source>
         <translation> Hz verticale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="115"/>
+        <location filename="globalStuff.h" line="116"/>
         <source> KHz horizontal, </source>
         <translation> KHz orizzontale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="116"/>
+        <location filename="globalStuff.h" line="117"/>
         <source> MHz dot clock</source>
         <translation> MHz dot clock</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="117"/>
+        <location filename="globalStuff.h" line="118"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="118"/>
+        <location filename="globalStuff.h" line="119"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="119"/>
+        <location filename="globalStuff.h" line="120"/>
         <source>Refresh rate</source>
         <translation>Frequenza di aggiornamento</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="120"/>
+        <location filename="globalStuff.h" line="121"/>
         <source>Offset</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="121"/>
+        <location filename="globalStuff.h" line="122"/>
         <source>Brightness (software)</source>
         <translation>Luminosità (software)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="122"/>
+        <location filename="globalStuff.h" line="123"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="123"/>
+        <location filename="globalStuff.h" line="124"/>
         <source>Supported modes</source>
         <translation>Modalità supportate</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="124"/>
+        <location filename="globalStuff.h" line="125"/>
         <source>Properties</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="125"/>
+        <location filename="globalStuff.h" line="126"/>
         <source>Serial number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="126"/>
+        <location filename="globalStuff.h" line="127"/>
         <source>Not available</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="127"/>
+        <location filename="globalStuff.h" line="128"/>
         <source>Connected with </source>
         <translation>Connesso con </translation>
     </message>
@@ -254,7 +254,7 @@
         <translation>Velocità della ventola</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="128"/>
+        <location filename="globalStuff.h" line="129"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
@@ -417,12 +417,17 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
         <translation>Non puoi modificare il primo e l&apos;ultimo elemento</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="82"/>
+        <location filename="globalStuff.h" line="80"/>
+        <source>An error occurred, overclock failed</source>
+        <translation>Si è verificato un errore, overclock fallito</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="83"/>
         <source>Process state: running</source>
         <translation>Processo in esecuzione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="160"/>
+        <location filename="globalStuff.h" line="161"/>
         <source>Version %n</source>
         <translation>Versione %n</translation>
     </message>
@@ -432,108 +437,108 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
         <translation>Il processo è ancora attivo. Chiudere comunque?</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="83"/>
+        <location filename="globalStuff.h" line="84"/>
         <source>Process state: not running</source>
         <translation>Processo terminato</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="84"/>
+        <location filename="globalStuff.h" line="85"/>
         <source>Save output to file</source>
         <translation>Salva output in un file</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="85"/>
+        <location filename="globalStuff.h" line="86"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="86"/>
+        <location filename="globalStuff.h" line="87"/>
         <source>Output</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="87"/>
+        <location filename="globalStuff.h" line="88"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="131"/>
+        <location filename="globalStuff.h" line="132"/>
         <source>%n mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="133"/>
+        <location filename="globalStuff.h" line="134"/>
         <source>%n mm </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="134"/>
+        <location filename="globalStuff.h" line="135"/>
         <source>(%n inches)</source>
         <translation>(%n pollici)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="130"/>
-        <location filename="globalStuff.h" line="132"/>
+        <location filename="globalStuff.h" line="131"/>
+        <location filename="globalStuff.h" line="133"/>
         <source>%n mm x </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="143"/>
+        <location filename="globalStuff.h" line="144"/>
         <source>%n°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="144"/>
         <location filename="globalStuff.h" line="145"/>
         <location filename="globalStuff.h" line="146"/>
         <location filename="globalStuff.h" line="147"/>
+        <location filename="globalStuff.h" line="148"/>
         <source>%nMHz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="148"/>
         <location filename="globalStuff.h" line="149"/>
+        <location filename="globalStuff.h" line="150"/>
         <source>%nmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="150"/>
+        <location filename="globalStuff.h" line="151"/>
         <source>%n%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="151"/>
+        <location filename="globalStuff.h" line="152"/>
         <source>Power level %n </source>
         <translation>Livello %n </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="152"/>
+        <location filename="globalStuff.h" line="153"/>
         <source>(GPU@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="153"/>
-        <location filename="globalStuff.h" line="155"/>
+        <location filename="globalStuff.h" line="154"/>
+        <location filename="globalStuff.h" line="156"/>
         <source>%nmV)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="154"/>
+        <location filename="globalStuff.h" line="155"/>
         <source>(Mem@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="135"/>
+        <location filename="globalStuff.h" line="136"/>
         <source>%n connected, </source>
         <translation>%n connessi, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="136"/>
+        <location filename="globalStuff.h" line="137"/>
         <source>%n active</source>
         <translation>%n attivi</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="129"/>
+        <location filename="globalStuff.h" line="130"/>
         <source>Virtual screen n°%n</source>
         <translatorcomment>Per un qualche motivo non viene tradotto correttamente a runtime, investigare</translatorcomment>
         <translation>Schermo virtuale n°%n</translation>
@@ -543,7 +548,7 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     <name>radeon_profile</name>
     <message>
         <location filename="radeon_profile.ui" line="20"/>
-        <location filename="radeon_profile.ui" line="3197"/>
+        <location filename="radeon_profile.ui" line="3382"/>
         <source>Radeon Profile</source>
         <translation></translation>
     </message>
@@ -589,7 +594,7 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     </message>
     <message>
         <location filename="radeon_profile.ui" line="500"/>
-        <location filename="radeon_profile.ui" line="3066"/>
+        <location filename="radeon_profile.ui" line="3251"/>
         <source>Property</source>
         <translation>Proprietà</translation>
     </message>
@@ -616,7 +621,7 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     </message>
     <message>
         <location filename="radeon_profile.ui" line="589"/>
-        <location filename="radeon_profile.ui" line="1155"/>
+        <location filename="radeon_profile.ui" line="1340"/>
         <source>Auto</source>
         <translation></translation>
     </message>
@@ -652,7 +657,7 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     </message>
     <message>
         <location filename="radeon_profile.ui" line="724"/>
-        <location filename="radeon_profile.ui" line="2935"/>
+        <location filename="radeon_profile.ui" line="3120"/>
         <source>Connectors</source>
         <translation>Connettori</translation>
     </message>
@@ -731,8 +736,8 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     </message>
     <message>
         <location filename="radeon_profile.ui" line="891"/>
-        <location filename="radeon_profile.ui" line="2878"/>
-        <location filename="radeon_profile.ui" line="3009"/>
+        <location filename="radeon_profile.ui" line="3063"/>
+        <location filename="radeon_profile.ui" line="3194"/>
         <source>Graphs</source>
         <translation>Grafici</translation>
     </message>
@@ -777,405 +782,428 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
         <translation>Temperature</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1135"/>
+        <location filename="radeon_profile.ui" line="1320"/>
         <source>Fan Control</source>
         <translation>Controllo ventola</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1180"/>
+        <location filename="radeon_profile.ui" line="1365"/>
         <source>Fixed</source>
         <translation>Fisso</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1202"/>
+        <location filename="radeon_profile.ui" line="1387"/>
         <source>Custom curve</source>
         <translation>Curva personalizzata</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1225"/>
+        <location filename="radeon_profile.ui" line="1410"/>
         <source>Info</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1248"/>
+        <location filename="radeon_profile.ui" line="1269"/>
+        <location filename="radeon_profile.ui" line="1433"/>
         <source>Apply</source>
         <translation>Applica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1270"/>
-        <location filename="radeon_profile.ui" line="1299"/>
+        <location filename="radeon_profile.ui" line="1135"/>
+        <source>Overclock</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="1164"/>
+        <source>Be careful! Overclock can harm your GPU, use it only if you know what you are doing!</source>
+        <oldsource>Be careful! Overclock can harm your GPU, use it at your own risk!</oldsource>
+        <translation>Stai attento! L&apos;overclock può danneggiare la tua GPU, usalo solo se sai quello che stai facendo!</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="1189"/>
+        <source>Enable overclock</source>
+        <translation>Abilita overclock</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="1199"/>
+        <source>Apply at launch</source>
+        <oldsource>Apply on startup</oldsource>
+        <translation>Applica all&apos;avvio</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="1455"/>
+        <location filename="radeon_profile.ui" line="1484"/>
         <source>20%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1312"/>
+        <location filename="radeon_profile.ui" line="1497"/>
         <source> / 100%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1339"/>
+        <location filename="radeon_profile.ui" line="1524"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1344"/>
+        <location filename="radeon_profile.ui" line="1529"/>
         <source>Fan Speed [%]</source>
         <translation>Velocità ventola [%]</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1366"/>
+        <location filename="radeon_profile.ui" line="1551"/>
         <source>Add step</source>
         <translation>Aggiungi punto</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1385"/>
+        <location filename="radeon_profile.ui" line="1570"/>
         <source>Remove step</source>
         <translation>Rimuovi punto</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1411"/>
+        <location filename="radeon_profile.ui" line="1596"/>
         <source>Exec</source>
         <translation>Eseguibili</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1871"/>
+        <location filename="radeon_profile.ui" line="2056"/>
         <source>Warning! Unrecommended root mode!</source>
         <translation>ATTENZIONE! L&apos;esecuzione di comandi in modalità root è sconsigliata!</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1893"/>
+        <location filename="radeon_profile.ui" line="2078"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1898"/>
+        <location filename="radeon_profile.ui" line="2083"/>
         <source>Binary</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1903"/>
+        <location filename="radeon_profile.ui" line="2088"/>
         <source>Params</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1908"/>
+        <location filename="radeon_profile.ui" line="2093"/>
         <source>Setting</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1913"/>
+        <location filename="radeon_profile.ui" line="2098"/>
         <source>Log file</source>
         <translation>File di log</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1918"/>
+        <location filename="radeon_profile.ui" line="2103"/>
         <source>Append date-time</source>
         <translation>Aggiungi data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1928"/>
+        <location filename="radeon_profile.ui" line="2113"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1935"/>
+        <location filename="radeon_profile.ui" line="2120"/>
         <source>Modify</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1942"/>
+        <location filename="radeon_profile.ui" line="2127"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1962"/>
+        <location filename="radeon_profile.ui" line="2147"/>
         <source>View output</source>
         <translation>Vedi output</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1975"/>
-        <location filename="radeon_profile.ui" line="2968"/>
+        <location filename="radeon_profile.ui" line="2160"/>
+        <location filename="radeon_profile.ui" line="3153"/>
         <source>Run</source>
         <translation>Esegui</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2005"/>
+        <location filename="radeon_profile.ui" line="2190"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2019"/>
+        <location filename="radeon_profile.ui" line="2204"/>
         <source>Binary:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2037"/>
-        <location filename="radeon_profile.ui" line="2082"/>
+        <location filename="radeon_profile.ui" line="2222"/>
+        <location filename="radeon_profile.ui" line="2267"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2050"/>
+        <location filename="radeon_profile.ui" line="2235"/>
         <source>Binary parameters:</source>
         <translation>Parametri:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2064"/>
+        <location filename="radeon_profile.ui" line="2249"/>
         <source>Log file: (leave empty if don&apos;t want it)</source>
         <translation>File di log (lascia vuoto se non ti interessa)</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2089"/>
+        <location filename="radeon_profile.ui" line="2274"/>
         <source>Append date and time</source>
         <translation>Aggiungi data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2106"/>
+        <location filename="radeon_profile.ui" line="2291"/>
         <source>Variables:</source>
         <translation>Variabili:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2130"/>
+        <location filename="radeon_profile.ui" line="2315"/>
         <source>Values:</source>
         <translation>Valori:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2159"/>
+        <location filename="radeon_profile.ui" line="2344"/>
         <source>Summary:</source>
         <translation>Sommario:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2181"/>
+        <location filename="radeon_profile.ui" line="2366"/>
         <source>Be careful, remember to save one space between variables.</source>
         <translation>Procedi con cautela, ricorda di aggiungere uno spazio fra le variabili.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2184"/>
+        <location filename="radeon_profile.ui" line="2369"/>
         <source>Tune variables manually</source>
         <translation>Modifica le variabili manualmente</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2611"/>
+        <location filename="radeon_profile.ui" line="2796"/>
         <source>Proceed with caution now.</source>
         <translation>Procedi con cautela.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2631"/>
+        <location filename="radeon_profile.ui" line="2816"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2638"/>
+        <location filename="radeon_profile.ui" line="2823"/>
         <source>OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2682"/>
+        <location filename="radeon_profile.ui" line="2867"/>
         <source>Configuration</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2707"/>
+        <location filename="radeon_profile.ui" line="2892"/>
         <source>Main</source>
         <translation>Generali</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2719"/>
+        <location filename="radeon_profile.ui" line="2904"/>
         <source>Start minimized</source>
         <translation>Avvia minimizzato</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2738"/>
+        <location filename="radeon_profile.ui" line="2923"/>
         <source>Minimize to tray</source>
         <translation>Minimizza nella barra delle applicazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2757"/>
+        <location filename="radeon_profile.ui" line="2942"/>
         <source>On close hide to tray</source>
         <translation>Minimizza invece di chiudere</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2770"/>
+        <location filename="radeon_profile.ui" line="2955"/>
         <source>Save window geometry</source>
         <translation>Salva la geometria della finestra</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2783"/>
+        <location filename="radeon_profile.ui" line="2968"/>
         <source>Alternate row colors on lists</source>
         <translation>Alterna i colori delle righe nelle liste</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2796"/>
+        <location filename="radeon_profile.ui" line="2981"/>
         <source>Refresh interval [s]</source>
         <translation>Intervallo di refresh [s]</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2837"/>
+        <location filename="radeon_profile.ui" line="3022"/>
         <source>Update:</source>
         <translation>Aggiornamento:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2856"/>
+        <location filename="radeon_profile.ui" line="3041"/>
         <source>GPU data, power profile, temperature</source>
         <translation>Dati GPU, profili, temperatura</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2894"/>
+        <location filename="radeon_profile.ui" line="3079"/>
         <source>Power levels statistics</source>
         <translation>Statistiche sul livello di potenza</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2916"/>
+        <location filename="radeon_profile.ui" line="3101"/>
         <source>GLX Info</source>
         <translation>Informazioni GLX</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2954"/>
+        <location filename="radeon_profile.ui" line="3139"/>
         <source>Module parameters</source>
         <translation>Parametri dei moduli</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2973"/>
+        <location filename="radeon_profile.ui" line="3158"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2987"/>
+        <location filename="radeon_profile.ui" line="3172"/>
         <source>Double click action on exec item</source>
         <translation>Doppio click su un eseguibile</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3000"/>
+        <location filename="radeon_profile.ui" line="3185"/>
         <source>Explicit append system env to exec command</source>
         <translation>Comando esplicito di aggiunta di data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3021"/>
+        <location filename="radeon_profile.ui" line="3206"/>
         <source>Line thickness:</source>
         <translation>Spessore della linea:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3071"/>
+        <location filename="radeon_profile.ui" line="3256"/>
         <source>Color</source>
         <translation>Colore</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3076"/>
+        <location filename="radeon_profile.ui" line="3261"/>
         <source>Temperature background</source>
         <translation>Sfondo temperature</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3081"/>
+        <location filename="radeon_profile.ui" line="3266"/>
         <source>Clocks background</source>
         <translation>Sfondo clock</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3086"/>
+        <location filename="radeon_profile.ui" line="3271"/>
         <source>Voltage background</source>
         <translation>Sfondo voltaggi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3091"/>
+        <location filename="radeon_profile.ui" line="3276"/>
         <source>Temperature line</source>
         <translation>Temperatura GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3096"/>
+        <location filename="radeon_profile.ui" line="3281"/>
         <source>GPU clock line</source>
         <translation>Clock della GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3101"/>
+        <location filename="radeon_profile.ui" line="3286"/>
         <source>Mem clock line</source>
         <translation>Clock della memoria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3106"/>
+        <location filename="radeon_profile.ui" line="3291"/>
         <source>UVD video core line</source>
         <translation>UVD video core</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3111"/>
+        <location filename="radeon_profile.ui" line="3296"/>
         <source>UVD decoder clock line</source>
         <translation>Decoder UVD</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3116"/>
+        <location filename="radeon_profile.ui" line="3301"/>
         <source>Core voltage line</source>
         <translation>Voltaggio della GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3121"/>
+        <location filename="radeon_profile.ui" line="3306"/>
         <source>Mem voltage line</source>
         <translation>Voltaggio della memoria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3128"/>
+        <location filename="radeon_profile.ui" line="3313"/>
         <source>Daemon</source>
         <translation>Background</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3143"/>
+        <location filename="radeon_profile.ui" line="3328"/>
         <source>Good option to check. Causes that daemon gets data from system automaticly with interval when GUI is on instead of waiting for request to read this data. Interval is the same as GUI.</source>
         <translation>Il servizio in background aggiornerà i dati automaticamente quando la GUI è attiva (consigliato).</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3146"/>
+        <location filename="radeon_profile.ui" line="3331"/>
         <source>Refresh data without request</source>
         <translation>Aggiorna dati automaticamente</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3162"/>
+        <location filename="radeon_profile.ui" line="3347"/>
         <source>Apply new configuration and send it to daemon.</source>
         <translation>Applica le opzioni e riconfigura il servizio in background.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3165"/>
+        <location filename="radeon_profile.ui" line="3350"/>
         <source>Reconfigure daemon</source>
         <translation>Riconfigura il demone</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3171"/>
+        <location filename="radeon_profile.ui" line="3356"/>
         <source>About</source>
         <translation>Dettagli</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3243"/>
+        <location filename="radeon_profile.ui" line="3428"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Go to GitHub repository&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Vai alla repository su GitHub&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3264"/>
+        <location filename="radeon_profile.ui" line="3449"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Report an issue&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Segnala un problema&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3285"/>
+        <location filename="radeon_profile.ui" line="3470"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile-daemon&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Radeon profile daemon&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3319"/>
+        <location filename="radeon_profile.ui" line="3504"/>
         <source>Contributors:</source>
         <translation>Contributori:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3334"/>
+        <location filename="radeon_profile.ui" line="3519"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Marazmista&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3355"/>
+        <location filename="radeon_profile.ui" line="3540"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/Danysan1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Danysan1&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3376"/>
+        <location filename="radeon_profile.ui" line="3561"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/V10lator&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;V10lator&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3397"/>
+        <location filename="radeon_profile.ui" line="3582"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/pontostroy&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Pontostroy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>

--- a/radeon-profile/strings.it.ts
+++ b/radeon-profile/strings.it.ts
@@ -4,391 +4,382 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="globalStuff.h" line="104"/>
+        <location filename="globalStuff.h" line="108"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="105"/>
+        <location filename="globalStuff.h" line="109"/>
         <source>Minimum resolution</source>
         <translation>Risoluzione minima</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="106"/>
+        <location filename="globalStuff.h" line="110"/>
         <source>Maximum resolution</source>
         <translation>Risoluzione massima</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="34"/>
+        <location filename="globalStuff.h" line="35"/>
         <source>Power level</source>
         <translation>Livello di potenza</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="35"/>
+        <location filename="globalStuff.h" line="36"/>
         <source>GPU clock</source>
         <translation>Clock della GPU</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="36"/>
+        <location filename="globalStuff.h" line="37"/>
         <source>Memory clock</source>
         <translation>Clock della memoria</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="37"/>
+        <location filename="globalStuff.h" line="38"/>
         <source>UVD core clock (cclk)</source>
         <translation>Clock del UVD (cclk)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="38"/>
+        <location filename="globalStuff.h" line="39"/>
         <source>UVD decoder clock (dclk)</source>
         <translation>Clock del decoder UVD (dclk)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="39"/>
+        <location filename="globalStuff.h" line="40"/>
         <source>GPU voltage (vddc)</source>
         <translation>Voltaggio GPU (vddc)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="40"/>
+        <location filename="globalStuff.h" line="41"/>
         <source>I/O voltage (vddci)</source>
-        <oldsource>Memory voltage (vddci)</oldsource>
         <translation>Voltaggio dell&apos;I/O</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="41"/>
+        <location filename="globalStuff.h" line="42"/>
         <source>GPU temperature</source>
         <translation>Temperatura della GPU</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="133"/>
+        <location filename="globalStuff.h" line="137"/>
         <source>No info</source>
         <translation>Nessuna info</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="136"/>
+        <location filename="globalStuff.h" line="140"/>
         <source>Back to profiles</source>
         <translation>Ritorna ai profili</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="137"/>
+        <location filename="globalStuff.h" line="141"/>
         <source>Can&apos;t read data</source>
         <translation>Impossibile leggere i dati</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="138"/>
+        <location filename="globalStuff.h" line="142"/>
         <source>You need debugfs mounted and either root rights or the daemon running</source>
-        <oldsource>To read the data you need debugfs mounted and either root rights or the daemon running</oldsource>
         <translation>È necessario che debugfs sia montato e che il demone sia attivo (o che il programma venga eseguito come root)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="86"/>
+        <location filename="globalStuff.h" line="90"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="87"/>
+        <location filename="globalStuff.h" line="91"/>
         <source>Profile name can&apos;t be empty!</source>
         <translation>Il nome del profilo non può essere vuoto!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="88"/>
+        <location filename="globalStuff.h" line="92"/>
         <source>No binary is selected!</source>
         <translation>Nessun eseguibile selezionato!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="89"/>
+        <location filename="globalStuff.h" line="93"/>
         <source>Binary not found in /usr/bin: </source>
         <translation>Eseguibile non trovato in /usr/bin: </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="90"/>
+        <location filename="globalStuff.h" line="94"/>
         <source>Enter value</source>
         <translation>Inserisci valore</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="91"/>
+        <location filename="globalStuff.h" line="95"/>
         <source>Enter valid value for </source>
         <translation>Inserisci un valore valido per </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="92"/>
+        <location filename="globalStuff.h" line="96"/>
         <source>Question</source>
         <translation></translation>
     </message>
     <message>
-        <source>Remove existing variable in summary?</source>
-        <translation type="vanished">Rimuovere la variabile dal sommario?</translation>
-    </message>
-    <message>
-        <location filename="globalStuff.h" line="94"/>
+        <location filename="globalStuff.h" line="98"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="93"/>
+        <location filename="globalStuff.h" line="97"/>
         <source>Remove this item?</source>
         <translation>Rimuovere questo elemento?</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="95"/>
+        <location filename="globalStuff.h" line="99"/>
         <source>Select binary</source>
         <translation>Seleziona un eseguibile</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="96"/>
+        <location filename="globalStuff.h" line="100"/>
         <source>Select log file</source>
         <translation>Seleziona un file di log</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="97"/>
+        <location filename="globalStuff.h" line="101"/>
         <source>Can&apos;t run something that not exists!</source>
         <translation>Non posso eseguire qualcosa che non esiste!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="98"/>
+        <location filename="globalStuff.h" line="102"/>
         <source>Run</source>
         <translation>Esegui</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="99"/>
+        <location filename="globalStuff.h" line="103"/>
         <source>Run: &quot;</source>
         <translation>Eseguire &quot;</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="100"/>
+        <location filename="globalStuff.h" line="104"/>
         <source>&quot;?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="103"/>
+        <location filename="globalStuff.h" line="107"/>
         <source>Unknown</source>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="107"/>
+        <location filename="globalStuff.h" line="111"/>
         <source>Virtual size</source>
         <translation>Dimensione virtuale</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="108"/>
+        <location filename="globalStuff.h" line="112"/>
         <source>Outputs</source>
         <translation>Connessioni</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="109"/>
+        <location filename="globalStuff.h" line="113"/>
         <source>Active</source>
         <translation>Attivo</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="110"/>
+        <location filename="globalStuff.h" line="114"/>
         <source> Hz vertical, </source>
         <translation> Hz verticale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="111"/>
+        <location filename="globalStuff.h" line="115"/>
         <source> KHz horizontal, </source>
         <translation> KHz orizzontale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="112"/>
+        <location filename="globalStuff.h" line="116"/>
         <source> MHz dot clock</source>
         <translation> MHz dot clock</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="113"/>
+        <location filename="globalStuff.h" line="117"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="114"/>
+        <location filename="globalStuff.h" line="118"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="115"/>
+        <location filename="globalStuff.h" line="119"/>
         <source>Refresh rate</source>
         <translation>Frequenza di aggiornamento</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="116"/>
+        <location filename="globalStuff.h" line="120"/>
         <source>Offset</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="117"/>
+        <location filename="globalStuff.h" line="121"/>
         <source>Brightness (software)</source>
         <translation>Luminosità (software)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="118"/>
+        <location filename="globalStuff.h" line="122"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="119"/>
+        <location filename="globalStuff.h" line="123"/>
         <source>Supported modes</source>
         <translation>Modalità supportate</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="120"/>
+        <location filename="globalStuff.h" line="124"/>
         <source>Properties</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="121"/>
+        <location filename="globalStuff.h" line="125"/>
         <source>Serial number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="122"/>
+        <location filename="globalStuff.h" line="126"/>
         <source>Not available</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="123"/>
+        <location filename="globalStuff.h" line="127"/>
         <source>Connected with </source>
         <translation>Connesso con </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="42"/>
+        <location filename="globalStuff.h" line="43"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="49"/>
+        <location filename="globalStuff.h" line="50"/>
         <source>Fan speed</source>
         <translation>Velocità della ventola</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="124"/>
+        <location filename="globalStuff.h" line="128"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="45"/>
+        <location filename="globalStuff.h" line="46"/>
         <source>Time (s)</source>
         <translation>Tempo (s)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="46"/>
+        <location filename="globalStuff.h" line="47"/>
         <source>Temperature (°C)</source>
         <translation>Temperatura (°C)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="47"/>
+        <location filename="globalStuff.h" line="48"/>
         <source>Clock (MHz)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="48"/>
+        <location filename="globalStuff.h" line="49"/>
         <source>Voltage (mV)</source>
         <translation>Voltaggio (mV)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="50"/>
+        <location filename="globalStuff.h" line="51"/>
         <source>DPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="51"/>
+        <location filename="globalStuff.h" line="52"/>
         <source>Change standard profile</source>
         <translation>Cambia profilo standard</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="52"/>
+        <location filename="globalStuff.h" line="53"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="53"/>
+        <location filename="globalStuff.h" line="54"/>
         <source>Keep refreshing when hidden</source>
         <translation>Continua a aggiornare quando nascosto</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="54"/>
+        <location filename="globalStuff.h" line="55"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="55"/>
+        <location filename="globalStuff.h" line="56"/>
         <source>Balanced</source>
         <translation>Bilanciato</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="56"/>
+        <location filename="globalStuff.h" line="57"/>
         <source>Performance</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="57"/>
+        <location filename="globalStuff.h" line="58"/>
         <source>Reset min/max temperature</source>
         <translation>Resetta temperatura min/max</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="58"/>
+        <location filename="globalStuff.h" line="59"/>
         <source>Reset graphs vertical scale</source>
         <translation>Resetta scala verticale dei grafici</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="59"/>
+        <location filename="globalStuff.h" line="60"/>
         <source>Show legend</source>
         <translation>Mostra la legenda</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="60"/>
+        <location filename="globalStuff.h" line="61"/>
         <source>Graph offset on right</source>
         <translation>Offset del grafico a destra</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="61"/>
+        <location filename="globalStuff.h" line="62"/>
         <source>Auto</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="62"/>
+        <location filename="globalStuff.h" line="63"/>
         <source>Low</source>
         <translation>Basso</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="63"/>
+        <location filename="globalStuff.h" line="64"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="64"/>
+        <location filename="globalStuff.h" line="65"/>
         <source>Force power level</source>
         <translation>Forza il livello di potenza</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="65"/>
+        <location filename="globalStuff.h" line="66"/>
         <source>Copy to clipboard</source>
         <translation>Copia negli appunti</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="66"/>
+        <location filename="globalStuff.h" line="67"/>
         <source>Reset statistics</source>
         <translation>Resetta le statistiche</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="69"/>
+        <location filename="globalStuff.h" line="70"/>
         <source>GPU data is disabled</source>
         <translation>Dati della GPU disabilitati</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="70"/>
+        <location filename="globalStuff.h" line="71"/>
         <source>Fan control information</source>
         <translation>Informazioni sul controllo della ventola</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="71"/>
+        <location filename="globalStuff.h" line="72"/>
         <source>Don&apos;t overheat your card! Be careful! Don&apos;t use this if you don&apos;t know what you&apos;re doing! 
 
 Hovewer, looks like card won&apos;t apply too low values due its internal protection. 
 
 Closing application will restore fan control to Auto. If application crashes, last fan value will remain, so you have been warned!</source>
-        <oldsource>Don&apos;t overheat your card! Be careful! Don&apos;t use this if you don&apos;t know what you&apos;re doing! 
-
-Hovewer, looks like card won&apos;t apply too low values due its internal protection. Closing application will restore fan control to Auto. If application crashes, last fan value will remain, so you have been warned.</oldsource>
         <translation>Non surriscaldare la tua scheda grafica! Usa questo sistema solo se sai quello che stai facendo!
 
 Il sistema di protezione della scheda grafica non accetta valori troppo bassi.
@@ -396,139 +387,153 @@ Il sistema di protezione della scheda grafica non accetta valori troppo bassi.
 Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola su Auto. Se l&apos;applicazione va in crash, l&apos;ultimo valore usato rimarrà attivo. Sei stato avvertito!</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="72"/>
+        <location filename="globalStuff.h" line="73"/>
         <source>Speed [%] (20-100)</source>
         <translation>Velocità [%] (20-100)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="73"/>
+        <location filename="globalStuff.h" line="74"/>
         <source>Select new power profile</source>
         <translation>Seleziona un nuovo profilo di potenza</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="74"/>
+        <location filename="globalStuff.h" line="75"/>
         <source>Profile selection</source>
         <translation>Selezione del profilo</translation>
     </message>
     <message>
+        <location filename="globalStuff.h" line="77"/>
+        <source>This step already exists. To edit it double click it</source>
+        <translation>Questo elemento è gia presente. Per modificarlo fai doppio click</translation>
+    </message>
+    <message>
         <location filename="globalStuff.h" line="78"/>
+        <source>You can&apos;t delete the first and the last item</source>
+        <translation>Non puoi cancellare il primo e l&apos;ultimo elemento</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="79"/>
+        <source>You can&apos;t edit the first and the last item</source>
+        <translation>Non puoi modificare il primo e l&apos;ultimo elemento</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="82"/>
         <source>Process state: running</source>
         <translation>Processo in esecuzione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="75"/>
+        <location filename="globalStuff.h" line="160"/>
+        <source>Version %n</source>
+        <translation>Versione %n</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="76"/>
         <source>Process is still running. Close tab?</source>
         <translation>Il processo è ancora attivo. Chiudere comunque?</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="79"/>
+        <location filename="globalStuff.h" line="83"/>
         <source>Process state: not running</source>
         <translation>Processo terminato</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="80"/>
+        <location filename="globalStuff.h" line="84"/>
         <source>Save output to file</source>
         <translation>Salva output in un file</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="81"/>
+        <location filename="globalStuff.h" line="85"/>
         <source>Command</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="82"/>
+        <location filename="globalStuff.h" line="86"/>
         <source>Output</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="83"/>
+        <location filename="globalStuff.h" line="87"/>
         <source>Save</source>
-        <oldsource>Save to </oldsource>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="127"/>
+        <location filename="globalStuff.h" line="131"/>
         <source>%n mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="129"/>
+        <location filename="globalStuff.h" line="133"/>
         <source>%n mm </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="130"/>
+        <location filename="globalStuff.h" line="134"/>
         <source>(%n inches)</source>
         <translation>(%n pollici)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="126"/>
-        <location filename="globalStuff.h" line="128"/>
+        <location filename="globalStuff.h" line="130"/>
+        <location filename="globalStuff.h" line="132"/>
         <source>%n mm x </source>
-        <oldsource>%n MHz</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="139"/>
-        <source>%n°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="globalStuff.h" line="140"/>
-        <location filename="globalStuff.h" line="141"/>
-        <location filename="globalStuff.h" line="142"/>
         <location filename="globalStuff.h" line="143"/>
-        <source>%nMHz</source>
-        <oldsource>%n %</oldsource>
+        <source>%n°C</source>
         <translation></translation>
     </message>
     <message>
         <location filename="globalStuff.h" line="144"/>
         <location filename="globalStuff.h" line="145"/>
+        <location filename="globalStuff.h" line="146"/>
+        <location filename="globalStuff.h" line="147"/>
+        <source>%nMHz</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="148"/>
+        <location filename="globalStuff.h" line="149"/>
         <source>%nmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="146"/>
+        <location filename="globalStuff.h" line="150"/>
         <source>%n%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="147"/>
+        <location filename="globalStuff.h" line="151"/>
         <source>Power level %n </source>
-        <oldsource>Power level %n</oldsource>
         <translation>Livello %n </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="148"/>
+        <location filename="globalStuff.h" line="152"/>
         <source>(GPU@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="149"/>
-        <location filename="globalStuff.h" line="151"/>
+        <location filename="globalStuff.h" line="153"/>
+        <location filename="globalStuff.h" line="155"/>
         <source>%nmV)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="150"/>
+        <location filename="globalStuff.h" line="154"/>
         <source>(Mem@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="131"/>
+        <location filename="globalStuff.h" line="135"/>
         <source>%n connected, </source>
-        <oldsource> connected, </oldsource>
         <translation>%n connessi, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="132"/>
+        <location filename="globalStuff.h" line="136"/>
         <source>%n active</source>
-        <oldsource> active</oldsource>
         <translation>%n attivi</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="125"/>
+        <location filename="globalStuff.h" line="129"/>
         <source>Virtual screen n°%n</source>
         <translatorcomment>Per un qualche motivo non viene tradotto correttamente a runtime, investigare</translatorcomment>
         <translation>Schermo virtuale n°%n</translation>
@@ -538,6 +543,7 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     <name>radeon_profile</name>
     <message>
         <location filename="radeon_profile.ui" line="20"/>
+        <location filename="radeon_profile.ui" line="3197"/>
         <source>Radeon Profile</source>
         <translation></translation>
     </message>
@@ -567,123 +573,122 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
         <translation>Clock della memoria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="349"/>
+        <location filename="radeon_profile.ui" line="336"/>
         <source>GPU voltage</source>
         <translation>Voltaggio della GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="389"/>
+        <location filename="radeon_profile.ui" line="376"/>
         <source>I/O voltage</source>
-        <oldsource>Memory voltage</oldsource>
         <translation>Voltaggio dell&apos;I/O</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="445"/>
+        <location filename="radeon_profile.ui" line="406"/>
         <source>GPU Summary</source>
         <translation>Sommario</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="539"/>
-        <location filename="radeon_profile.ui" line="3105"/>
+        <location filename="radeon_profile.ui" line="500"/>
+        <location filename="radeon_profile.ui" line="3066"/>
         <source>Property</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="544"/>
-        <location filename="radeon_profile.ui" line="858"/>
+        <location filename="radeon_profile.ui" line="505"/>
+        <location filename="radeon_profile.ui" line="819"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="583"/>
+        <location filename="radeon_profile.ui" line="544"/>
         <source>Profiles</source>
         <translation>Profili</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="595"/>
+        <location filename="radeon_profile.ui" line="556"/>
         <source>Change profile</source>
         <translation>Cambia profilo</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="601"/>
+        <location filename="radeon_profile.ui" line="562"/>
         <source>DPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="628"/>
-        <location filename="radeon_profile.ui" line="1194"/>
+        <location filename="radeon_profile.ui" line="589"/>
+        <location filename="radeon_profile.ui" line="1155"/>
         <source>Auto</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="641"/>
+        <location filename="radeon_profile.ui" line="602"/>
         <source>Battery</source>
         <translation>Batteria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="661"/>
+        <location filename="radeon_profile.ui" line="622"/>
         <source>Balanced</source>
         <translation>Bilanciato</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="678"/>
+        <location filename="radeon_profile.ui" line="639"/>
         <source>Performance</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="695"/>
+        <location filename="radeon_profile.ui" line="656"/>
         <source>Low</source>
         <translation>Basso</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="708"/>
+        <location filename="radeon_profile.ui" line="669"/>
         <source>High</source>
         <translation>Alto</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="726"/>
+        <location filename="radeon_profile.ui" line="687"/>
         <source>GLX info</source>
         <translation>Informazioni GLX</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="763"/>
-        <location filename="radeon_profile.ui" line="2974"/>
+        <location filename="radeon_profile.ui" line="724"/>
+        <location filename="radeon_profile.ui" line="2935"/>
         <source>Connectors</source>
         <translation>Connettori</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="800"/>
+        <location filename="radeon_profile.ui" line="761"/>
         <source>Connector</source>
         <translation>Componente</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="805"/>
+        <location filename="radeon_profile.ui" line="766"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="814"/>
+        <location filename="radeon_profile.ui" line="775"/>
         <source>Module info</source>
         <translation>Informazioni del modulo</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="853"/>
+        <location filename="radeon_profile.ui" line="814"/>
         <source>Option</source>
         <translation>Opzione</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="863"/>
+        <location filename="radeon_profile.ui" line="824"/>
         <source>Description</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="872"/>
+        <location filename="radeon_profile.ui" line="833"/>
         <source>Stats</source>
         <translation>Statistiche</translation>
     </message>
     <message>
         <location filename="radeon_profile.ui" line="157"/>
-        <location filename="radeon_profile.ui" line="912"/>
+        <location filename="radeon_profile.ui" line="873"/>
         <source>Power level</source>
         <translation>Livello di potenza</translation>
     </message>
@@ -700,438 +705,479 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
     <message>
         <location filename="radeon_profile.ui" line="191"/>
         <source>999%</source>
-        <oldsource>999 %</oldsource>
         <translation></translation>
     </message>
     <message>
         <location filename="radeon_profile.ui" line="228"/>
         <source>99.9°C</source>
-        <oldsource>999°C</oldsource>
         <translation></translation>
     </message>
     <message>
         <location filename="radeon_profile.ui" line="265"/>
         <location filename="radeon_profile.ui" line="302"/>
         <source>9999MHz</source>
-        <oldsource>9999 MHz</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="355"/>
-        <location filename="radeon_profile.ui" line="392"/>
+        <location filename="radeon_profile.ui" line="342"/>
+        <location filename="radeon_profile.ui" line="379"/>
         <source>9999mV</source>
-        <oldsource>9999 mV</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="917"/>
+        <location filename="radeon_profile.ui" line="878"/>
         <source>Time</source>
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="930"/>
-        <location filename="radeon_profile.ui" line="2917"/>
-        <location filename="radeon_profile.ui" line="3048"/>
+        <location filename="radeon_profile.ui" line="891"/>
+        <location filename="radeon_profile.ui" line="2878"/>
+        <location filename="radeon_profile.ui" line="3009"/>
         <source>Graphs</source>
         <translation>Grafici</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1002"/>
+        <location filename="radeon_profile.ui" line="963"/>
         <source>Reset min max temps and graphs scale</source>
         <translation>Resetta la scala del grafico</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1005"/>
+        <location filename="radeon_profile.ui" line="966"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1018"/>
+        <location filename="radeon_profile.ui" line="979"/>
         <source>Clocks graph</source>
         <translation>Grafico dei clock</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1050"/>
+        <location filename="radeon_profile.ui" line="1011"/>
         <source>Volts graph</source>
         <translation>Grafico dei voltaggi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1063"/>
+        <location filename="radeon_profile.ui" line="1024"/>
         <source>Temperature graph</source>
         <translation>Grafico delle temperature</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1137"/>
+        <location filename="radeon_profile.ui" line="1098"/>
         <source>1h</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1144"/>
+        <location filename="radeon_profile.ui" line="1105"/>
         <source>30s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1163"/>
+        <location filename="radeon_profile.ui" line="1124"/>
         <source>temps label</source>
         <translation>Temperature</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1174"/>
+        <location filename="radeon_profile.ui" line="1135"/>
         <source>Fan Control</source>
         <translation>Controllo ventola</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1219"/>
+        <location filename="radeon_profile.ui" line="1180"/>
         <source>Fixed</source>
         <translation>Fisso</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1241"/>
+        <location filename="radeon_profile.ui" line="1202"/>
         <source>Custom curve</source>
         <translation>Curva personalizzata</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1264"/>
+        <location filename="radeon_profile.ui" line="1225"/>
         <source>Info</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1287"/>
+        <location filename="radeon_profile.ui" line="1248"/>
         <source>Apply</source>
         <translation>Applica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1309"/>
-        <location filename="radeon_profile.ui" line="1338"/>
+        <location filename="radeon_profile.ui" line="1270"/>
+        <location filename="radeon_profile.ui" line="1299"/>
         <source>20%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1351"/>
+        <location filename="radeon_profile.ui" line="1312"/>
         <source> / 100%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1378"/>
+        <location filename="radeon_profile.ui" line="1339"/>
         <source>Temperature</source>
         <translation>Temperatura</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1383"/>
+        <location filename="radeon_profile.ui" line="1344"/>
         <source>Fan Speed [%]</source>
         <translation>Velocità ventola [%]</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1405"/>
+        <location filename="radeon_profile.ui" line="1366"/>
         <source>Add step</source>
         <translation>Aggiungi punto</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1424"/>
+        <location filename="radeon_profile.ui" line="1385"/>
         <source>Remove step</source>
         <translation>Rimuovi punto</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1450"/>
+        <location filename="radeon_profile.ui" line="1411"/>
         <source>Exec</source>
         <translation>Eseguibili</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1910"/>
+        <location filename="radeon_profile.ui" line="1871"/>
         <source>Warning! Unrecommended root mode!</source>
         <translation>ATTENZIONE! L&apos;esecuzione di comandi in modalità root è sconsigliata!</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1932"/>
+        <location filename="radeon_profile.ui" line="1893"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1937"/>
+        <location filename="radeon_profile.ui" line="1898"/>
         <source>Binary</source>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1942"/>
+        <location filename="radeon_profile.ui" line="1903"/>
         <source>Params</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1947"/>
+        <location filename="radeon_profile.ui" line="1908"/>
         <source>Setting</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1952"/>
+        <location filename="radeon_profile.ui" line="1913"/>
         <source>Log file</source>
         <translation>File di log</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1957"/>
+        <location filename="radeon_profile.ui" line="1918"/>
         <source>Append date-time</source>
         <translation>Aggiungi data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1967"/>
+        <location filename="radeon_profile.ui" line="1928"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1974"/>
+        <location filename="radeon_profile.ui" line="1935"/>
         <source>Modify</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="1981"/>
+        <location filename="radeon_profile.ui" line="1942"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2001"/>
+        <location filename="radeon_profile.ui" line="1962"/>
         <source>View output</source>
         <translation>Vedi output</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2014"/>
-        <location filename="radeon_profile.ui" line="3007"/>
+        <location filename="radeon_profile.ui" line="1975"/>
+        <location filename="radeon_profile.ui" line="2968"/>
         <source>Run</source>
         <translation>Esegui</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2044"/>
+        <location filename="radeon_profile.ui" line="2005"/>
         <source>Name:</source>
         <translation>Nome:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2058"/>
+        <location filename="radeon_profile.ui" line="2019"/>
         <source>Binary:</source>
         <translation>Comando:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2076"/>
-        <location filename="radeon_profile.ui" line="2121"/>
+        <location filename="radeon_profile.ui" line="2037"/>
+        <location filename="radeon_profile.ui" line="2082"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2089"/>
+        <location filename="radeon_profile.ui" line="2050"/>
         <source>Binary parameters:</source>
         <translation>Parametri:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2103"/>
+        <location filename="radeon_profile.ui" line="2064"/>
         <source>Log file: (leave empty if don&apos;t want it)</source>
         <translation>File di log (lascia vuoto se non ti interessa)</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2128"/>
+        <location filename="radeon_profile.ui" line="2089"/>
         <source>Append date and time</source>
         <translation>Aggiungi data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2145"/>
+        <location filename="radeon_profile.ui" line="2106"/>
         <source>Variables:</source>
         <translation>Variabili:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2169"/>
+        <location filename="radeon_profile.ui" line="2130"/>
         <source>Values:</source>
         <translation>Valori:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2198"/>
+        <location filename="radeon_profile.ui" line="2159"/>
         <source>Summary:</source>
         <translation>Sommario:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2220"/>
+        <location filename="radeon_profile.ui" line="2181"/>
         <source>Be careful, remember to save one space between variables.</source>
         <translation>Procedi con cautela, ricorda di aggiungere uno spazio fra le variabili.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2223"/>
+        <location filename="radeon_profile.ui" line="2184"/>
         <source>Tune variables manually</source>
         <translation>Modifica le variabili manualmente</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2650"/>
+        <location filename="radeon_profile.ui" line="2611"/>
         <source>Proceed with caution now.</source>
         <translation>Procedi con cautela.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2670"/>
+        <location filename="radeon_profile.ui" line="2631"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2677"/>
+        <location filename="radeon_profile.ui" line="2638"/>
         <source>OK</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2721"/>
+        <location filename="radeon_profile.ui" line="2682"/>
         <source>Configuration</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2746"/>
+        <location filename="radeon_profile.ui" line="2707"/>
         <source>Main</source>
         <translation>Generali</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2758"/>
+        <location filename="radeon_profile.ui" line="2719"/>
         <source>Start minimized</source>
         <translation>Avvia minimizzato</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2777"/>
+        <location filename="radeon_profile.ui" line="2738"/>
         <source>Minimize to tray</source>
         <translation>Minimizza nella barra delle applicazioni</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2796"/>
+        <location filename="radeon_profile.ui" line="2757"/>
         <source>On close hide to tray</source>
         <translation>Minimizza invece di chiudere</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2809"/>
+        <location filename="radeon_profile.ui" line="2770"/>
         <source>Save window geometry</source>
         <translation>Salva la geometria della finestra</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2822"/>
+        <location filename="radeon_profile.ui" line="2783"/>
         <source>Alternate row colors on lists</source>
         <translation>Alterna i colori delle righe nelle liste</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2835"/>
+        <location filename="radeon_profile.ui" line="2796"/>
         <source>Refresh interval [s]</source>
         <translation>Intervallo di refresh [s]</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2876"/>
+        <location filename="radeon_profile.ui" line="2837"/>
         <source>Update:</source>
         <translation>Aggiornamento:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2895"/>
+        <location filename="radeon_profile.ui" line="2856"/>
         <source>GPU data, power profile, temperature</source>
         <translation>Dati GPU, profili, temperatura</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2933"/>
+        <location filename="radeon_profile.ui" line="2894"/>
         <source>Power levels statistics</source>
         <translation>Statistiche sul livello di potenza</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2955"/>
+        <location filename="radeon_profile.ui" line="2916"/>
         <source>GLX Info</source>
         <translation>Informazioni GLX</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="2993"/>
+        <location filename="radeon_profile.ui" line="2954"/>
         <source>Module parameters</source>
         <translation>Parametri dei moduli</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3012"/>
+        <location filename="radeon_profile.ui" line="2973"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3026"/>
+        <location filename="radeon_profile.ui" line="2987"/>
         <source>Double click action on exec item</source>
         <translation>Doppio click su un eseguibile</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3039"/>
+        <location filename="radeon_profile.ui" line="3000"/>
         <source>Explicit append system env to exec command</source>
         <translation>Comando esplicito di aggiunta di data e ora</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3060"/>
+        <location filename="radeon_profile.ui" line="3021"/>
         <source>Line thickness:</source>
         <translation>Spessore della linea:</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3110"/>
+        <location filename="radeon_profile.ui" line="3071"/>
         <source>Color</source>
         <translation>Colore</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3115"/>
+        <location filename="radeon_profile.ui" line="3076"/>
         <source>Temperature background</source>
         <translation>Sfondo temperature</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3120"/>
+        <location filename="radeon_profile.ui" line="3081"/>
         <source>Clocks background</source>
         <translation>Sfondo clock</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3125"/>
+        <location filename="radeon_profile.ui" line="3086"/>
         <source>Voltage background</source>
         <translation>Sfondo voltaggi</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3130"/>
+        <location filename="radeon_profile.ui" line="3091"/>
         <source>Temperature line</source>
         <translation>Temperatura GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3135"/>
+        <location filename="radeon_profile.ui" line="3096"/>
         <source>GPU clock line</source>
         <translation>Clock della GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3140"/>
+        <location filename="radeon_profile.ui" line="3101"/>
         <source>Mem clock line</source>
         <translation>Clock della memoria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3145"/>
+        <location filename="radeon_profile.ui" line="3106"/>
         <source>UVD video core line</source>
         <translation>UVD video core</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3150"/>
+        <location filename="radeon_profile.ui" line="3111"/>
         <source>UVD decoder clock line</source>
         <translation>Decoder UVD</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3155"/>
+        <location filename="radeon_profile.ui" line="3116"/>
         <source>Core voltage line</source>
         <translation>Voltaggio della GPU</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3160"/>
+        <location filename="radeon_profile.ui" line="3121"/>
         <source>Mem voltage line</source>
         <translation>Voltaggio della memoria</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3167"/>
+        <location filename="radeon_profile.ui" line="3128"/>
         <source>Daemon</source>
         <translation>Background</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3182"/>
+        <location filename="radeon_profile.ui" line="3143"/>
         <source>Good option to check. Causes that daemon gets data from system automaticly with interval when GUI is on instead of waiting for request to read this data. Interval is the same as GUI.</source>
         <translation>Il servizio in background aggiornerà i dati automaticamente quando la GUI è attiva (consigliato).</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3185"/>
+        <location filename="radeon_profile.ui" line="3146"/>
         <source>Refresh data without request</source>
         <translation>Aggiorna dati automaticamente</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3201"/>
+        <location filename="radeon_profile.ui" line="3162"/>
         <source>Apply new configuration and send it to daemon.</source>
         <translation>Applica le opzioni e riconfigura il servizio in background.</translation>
     </message>
     <message>
-        <location filename="radeon_profile.ui" line="3204"/>
+        <location filename="radeon_profile.ui" line="3165"/>
         <source>Reconfigure daemon</source>
         <translation>Riconfigura il demone</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3171"/>
+        <source>About</source>
+        <translation>Dettagli</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3243"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Go to GitHub repository&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Vai alla repository su GitHub&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3264"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Report an issue&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Segnala un problema&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3285"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista/radeon-profile-daemon&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Radeon profile daemon&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3319"/>
+        <source>Contributors:</source>
+        <translation>Contributori:</translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3334"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/marazmista&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Marazmista&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3355"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/Danysan1&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Danysan1&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3376"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/V10lator&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;V10lator&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="radeon_profile.ui" line="3397"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://github.com/pontostroy&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#2980b9;&quot;&gt;Pontostroy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation></translation>
     </message>
 </context>
 </TS>

--- a/radeon-profile/strings.it.ts
+++ b/radeon-profile/strings.it.ts
@@ -4,17 +4,17 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="globalStuff.h" line="103"/>
+        <location filename="globalStuff.h" line="104"/>
         <source>Resolution</source>
         <translation>Risoluzione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="104"/>
+        <location filename="globalStuff.h" line="105"/>
         <source>Minimum resolution</source>
         <translation>Risoluzione minima</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="105"/>
+        <location filename="globalStuff.h" line="106"/>
         <source>Maximum resolution</source>
         <translation>Risoluzione massima</translation>
     </message>
@@ -60,17 +60,22 @@
         <translation>Temperatura della GPU</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="134"/>
+        <location filename="globalStuff.h" line="133"/>
+        <source>No info</source>
+        <translation>Nessuna info</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="136"/>
         <source>Back to profiles</source>
         <translation>Ritorna ai profili</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="135"/>
+        <location filename="globalStuff.h" line="137"/>
         <source>Can&apos;t read data</source>
         <translation>Impossibile leggere i dati</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="136"/>
+        <location filename="globalStuff.h" line="138"/>
         <source>You need debugfs mounted and either root rights or the daemon running</source>
         <oldsource>To read the data you need debugfs mounted and either root rights or the daemon running</oldsource>
         <translation>È necessario che debugfs sia montato e che il demone sia attivo (o che il programma venga eseguito come root)</translation>
@@ -155,87 +160,92 @@
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="106"/>
+        <location filename="globalStuff.h" line="103"/>
+        <source>Unknown</source>
+        <translation>Sconosciuto</translation>
+    </message>
+    <message>
+        <location filename="globalStuff.h" line="107"/>
         <source>Virtual size</source>
         <translation>Dimensione virtuale</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="107"/>
+        <location filename="globalStuff.h" line="108"/>
         <source>Outputs</source>
         <translation>Connessioni</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="108"/>
+        <location filename="globalStuff.h" line="109"/>
         <source>Active</source>
         <translation>Attivo</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="109"/>
+        <location filename="globalStuff.h" line="110"/>
         <source> Hz vertical, </source>
         <translation> Hz verticale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="110"/>
+        <location filename="globalStuff.h" line="111"/>
         <source> KHz horizontal, </source>
         <translation> KHz orizzontale, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="111"/>
+        <location filename="globalStuff.h" line="112"/>
         <source> MHz dot clock</source>
         <translation> MHz dot clock</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="112"/>
+        <location filename="globalStuff.h" line="113"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="113"/>
+        <location filename="globalStuff.h" line="114"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="114"/>
+        <location filename="globalStuff.h" line="115"/>
         <source>Refresh rate</source>
         <translation>Frequenza di aggiornamento</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="115"/>
+        <location filename="globalStuff.h" line="116"/>
         <source>Offset</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="116"/>
+        <location filename="globalStuff.h" line="117"/>
         <source>Brightness (software)</source>
         <translation>Luminosità (software)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="117"/>
+        <location filename="globalStuff.h" line="118"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="118"/>
+        <location filename="globalStuff.h" line="119"/>
         <source>Supported modes</source>
         <translation>Modalità supportate</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="119"/>
+        <location filename="globalStuff.h" line="120"/>
         <source>Properties</source>
         <translation>Proprietà</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="120"/>
+        <location filename="globalStuff.h" line="121"/>
         <source>Serial number</source>
         <translation>Numero di serie</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="121"/>
+        <location filename="globalStuff.h" line="122"/>
         <source>Not available</source>
         <translation>Non disponibile</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="122"/>
+        <location filename="globalStuff.h" line="123"/>
         <source>Connected with </source>
         <translation>Connesso con </translation>
     </message>
@@ -250,7 +260,7 @@
         <translation>Velocità della ventola</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="123"/>
+        <location filename="globalStuff.h" line="124"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
@@ -437,88 +447,88 @@ Prima di chiudersi, l&apos;applicazione reimposterà il controllo della ventola 
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="126"/>
+        <location filename="globalStuff.h" line="127"/>
         <source>%n mm</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="128"/>
+        <location filename="globalStuff.h" line="129"/>
         <source>%n mm </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="129"/>
+        <location filename="globalStuff.h" line="130"/>
         <source>(%n inches)</source>
         <translation>(%n pollici)</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="125"/>
-        <location filename="globalStuff.h" line="127"/>
+        <location filename="globalStuff.h" line="126"/>
+        <location filename="globalStuff.h" line="128"/>
         <source>%n mm x </source>
         <oldsource>%n MHz</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="137"/>
+        <location filename="globalStuff.h" line="139"/>
         <source>%n°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="138"/>
-        <location filename="globalStuff.h" line="139"/>
         <location filename="globalStuff.h" line="140"/>
         <location filename="globalStuff.h" line="141"/>
+        <location filename="globalStuff.h" line="142"/>
+        <location filename="globalStuff.h" line="143"/>
         <source>%nMHz</source>
         <oldsource>%n %</oldsource>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="142"/>
-        <location filename="globalStuff.h" line="143"/>
+        <location filename="globalStuff.h" line="144"/>
+        <location filename="globalStuff.h" line="145"/>
         <source>%nmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="144"/>
+        <location filename="globalStuff.h" line="146"/>
         <source>%n%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="145"/>
+        <location filename="globalStuff.h" line="147"/>
         <source>Power level %n </source>
         <oldsource>Power level %n</oldsource>
         <translation>Livello %n </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="146"/>
+        <location filename="globalStuff.h" line="148"/>
         <source>(GPU@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="147"/>
         <location filename="globalStuff.h" line="149"/>
+        <location filename="globalStuff.h" line="151"/>
         <source>%nmV)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="148"/>
+        <location filename="globalStuff.h" line="150"/>
         <source>(Mem@%nMHz,</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="130"/>
+        <location filename="globalStuff.h" line="131"/>
         <source>%n connected, </source>
         <oldsource> connected, </oldsource>
         <translation>%n connessi, </translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="131"/>
+        <location filename="globalStuff.h" line="132"/>
         <source>%n active</source>
         <oldsource> active</oldsource>
         <translation>%n attivi</translation>
     </message>
     <message>
-        <location filename="globalStuff.h" line="124"/>
+        <location filename="globalStuff.h" line="125"/>
         <source>Virtual screen n°%n</source>
         <translatorcomment>Per un qualche motivo non viene tradotto correttamente a runtime, investigare</translatorcomment>
         <translation>Schermo virtuale n°%n</translation>

--- a/radeon-profile/uiEvents.cpp
+++ b/radeon-profile/uiEvents.cpp
@@ -411,14 +411,15 @@ void radeon_profile::on_list_fanSteps_itemDoubleClicked(QTreeWidgetItem *item, i
                 fanSteps.remove(oldTemp);
                 delete item;
                 ui->plotFanProfile->graph(0)->removeData(oldTemp);
+                addFanStep(newTemp,newSpeed);
             }
         } else { // The user wants to change the speed
             newTemp = oldTemp;
             newSpeed = askNumber(oldSpeed, minFanStepsSpeed, maxFanStepsSpeed, label_fanSpeedRange);
             // addFanStep() will check the validity of newSpeed and overwrite the current step
+            addFanStep(newTemp,newSpeed);
         }
 
-        addFanStep(newTemp,newSpeed);
     }
 
 }

--- a/radeon-profile/uiEvents.cpp
+++ b/radeon-profile/uiEvents.cpp
@@ -75,9 +75,7 @@ void radeon_profile::on_btn_pwmProfile_clicked()
 
     device.setPwmManualControl(true);
 
-    // we only figure out if there is a need of counting all the math
-    // if temperature has changed, so reset
-    device.gpuTemeperatureData.currentBefore = 0;
+    adjustFanSpeed(true);
 }
 
 void radeon_profile::changeProfileFromCombo() {
@@ -361,18 +359,20 @@ void radeon_profile::on_btn_fanInfo_clicked()
 
 void radeon_profile::on_btn_addFanStep_clicked()
 {
-    int temperature = askNumber(0,10,100, label_temperature);
-    if (temperature == -1)
+    const int temperature = askNumber(0, minFanStepsTemp, maxFanStepsTemp, label_temperature);
+    if (temperature == -1) // User clicked Cancel
         return;
 
-    int fanSpeed = askNumber(0,20,100, label_fanSpeedRange);
-    if (fanSpeed == -1)
-        return;
+    if (fanSteps.contains(temperature)) // A step with this temperature already exists
+        QMessageBox::warning(this, label_error, label_howToEdit);
+    else { // This step does not exist, proceed
+        const int fanSpeed = askNumber(0, minFanStepsSpeed, maxFanStepsSpeed, label_fanSpeedRange);
+        if (fanSpeed == -1) // User clicked Cancel
+            return;
 
-    fanSteps.insert(fanSteps.count()-1,fanStepPair(temperature,fanSpeed));
-    ui->list_fanSteps->insertTopLevelItem(ui->list_fanSteps->topLevelItemCount()-1,new QTreeWidgetItem(QStringList() << QString().setNum(temperature) << QString().setNum(fanSpeed)));
+        addFanStep(temperature,fanSpeed);
 
-    makeFanProfileGraph(fanSteps);
+    }
 }
 
 void radeon_profile::on_btn_removeFanStep_clicked()
@@ -380,57 +380,47 @@ void radeon_profile::on_btn_removeFanStep_clicked()
     QTreeWidgetItem *current = ui->list_fanSteps->currentItem();
 
     if (ui->list_fanSteps->indexOfTopLevelItem(current) == 0 || ui->list_fanSteps->indexOfTopLevelItem(current) == ui->list_fanSteps->topLevelItemCount()-1)
-            return;
+        // The selected item is the first or the last, it can't be deleted
+        QMessageBox::warning(this, label_error, label_cantDeleteThisItem);
+    else { // The selected item can be removed, remove it
+        int temperature = current->text(0).toInt();
 
-    int temperature = current->text(0).toInt();
+        fanSteps.remove(temperature);
+        adjustFanSpeed(true);
 
-    for (int i = 0; i < fanSteps.count(); ++i) {
-        if (fanSteps.at(i).temperature == temperature) {
-            fanSteps.removeAt(i);
-            break;
-        }
+        // Remove the step from the list and from the graph
+        delete current;
+        ui->plotFanProfile->graph(0)->removeData(temperature);
+        ui->plotFanProfile->replot();
     }
-
-    delete ui->list_fanSteps->currentItem();
-    makeFanProfileGraph(fanSteps);
 }
 
 void radeon_profile::on_list_fanSteps_itemDoubleClicked(QTreeWidgetItem *item, int column)
 {
     if (ui->list_fanSteps->indexOfTopLevelItem(item) == 0 || ui->list_fanSteps->indexOfTopLevelItem(item) == ui->list_fanSteps->topLevelItemCount()-1)
-        return;
+        // The selected item is the first or the last, it can't be edited
+        QMessageBox::warning(this, label_error, label_cantEditThisItem);
+    else{ // Edit the item
+        const int oldTemp = item->text(0).toInt(), oldSpeed = item->text(1).toInt();
+        int newTemp, newSpeed;
 
-    int value;
-    switch (column) {
-    case 0:
-        value = askNumber(item->text(0).toInt(),10,100, label_temperature);
-
-        if (value == -1)
-            return;
-
-        for (int i =0; i < fanSteps.count(); ++i) {
-            if (fanSteps.at(i).speed == item->text(1).toInt()) {
-                fanSteps[i].temperature = value;
-                break;
+        if(column == 0){ // The user wants to change the temperature
+            newTemp = askNumber(oldTemp, minFanStepsTemp, maxFanStepsTemp, label_temperature);
+            if(newTemp != -1){
+                newSpeed = oldSpeed;
+                fanSteps.remove(oldTemp);
+                delete item;
+                ui->plotFanProfile->graph(0)->removeData(oldTemp);
             }
+        } else { // The user wants to change the speed
+            newTemp = oldTemp;
+            newSpeed = askNumber(oldSpeed, minFanStepsSpeed, maxFanStepsSpeed, label_fanSpeedRange);
+            // addFanStep() will check the validity of newSpeed and overwrite the current step
         }
-        break;
-    case 1:
-        value = askNumber(item->text(1).toInt(),20,100, label_fanSpeedRange);
-        if (value == -1)
-            return;
 
-        for (int i =0; i < fanSteps.count(); ++i) {
-            if (fanSteps.at(i).temperature == item->text(0).toInt()) {
-                fanSteps[i].speed = value;
-                break;
-            }
-        }
-        break;
+        addFanStep(newTemp,newSpeed);
     }
 
-    item->setText(column,QString().setNum(value));
-    makeFanProfileGraph(fanSteps);
 }
 
 int radeon_profile::askNumber(const int value, const int min, const int max, const QString label) {

--- a/radeon-profile/uiEvents.cpp
+++ b/radeon-profile/uiEvents.cpp
@@ -440,3 +440,25 @@ void radeon_profile::on_fanSpeedSlider_valueChanged(int value)
 }
 
 //========
+
+void radeon_profile::on_cb_enableOverclock_toggled(const bool enable){
+    ui->slider_overclock->setEnabled(enable);
+    ui->btn_applyOverclock->setEnabled(enable);
+    ui->cb_overclockAtLaunch->setEnabled(enable);
+
+    if(enable)
+        qDebug() << "Enabling overclock";
+    else {
+        qDebug() << "Disabling overclock";
+        device.resetOverclock();
+    }
+}
+
+void radeon_profile::on_btn_applyOverclock_clicked(){
+    if( ! device.overclock(ui->slider_overclock->value()))
+        QMessageBox::warning(this, label_error, label_overclockFailed);
+}
+
+void radeon_profile::on_slider_overclock_valueChanged(const int value){
+    ui->label_overclockPercentage->setText(QString::number(value));
+}


### PR DESCRIPTION
 - dxorg.cpp: Fixed misleading while() declaration.
 - radeon_profile.cpp: removed repeated call for `l_cClk->setVisible()`; Added
calls that hide header labels and separators if the values are not
avalable and valid:
![screenshot_20160508_133955](https://cloud.githubusercontent.com/assets/8406735/15097699/79d3a0dc-1524-11e6-9c24-b4fbcbd85560.png)
![screenshot_20160508_134015](https://cloud.githubusercontent.com/assets/8406735/15097700/7cd3a598-1524-11e6-8124-544623e429c6.png)
![screenshot_20160508_134033](https://cloud.githubusercontent.com/assets/8406735/15097701/7ef76d96-1524-11e6-920a-274925c9b3e7.png)
 - gpu.cpp, globalStuff.h, strings.it.ts: Translated 2 strings.
 - dxorg.h, globalStuff.h: Cleanup on struct declarations.
 - radeon_profile.ui: increased combo_gpus size, reduced
combo_pLevel and combo_pProfile size.