### PR TITLE
Check size of QMap before assuming size of 2

### DIFF
--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -25,7 +25,6 @@
 #include <QDateTime>
 #include <QMessageBox>
 #include <QDebug>
-#include <iostream>
 
 radeon_profile::radeon_profile(QStringList a,QWidget *parent) :
     QMainWindow(parent),

--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -25,6 +25,7 @@
 #include <QDateTime>
 #include <QMessageBox>
 #include <QDebug>
+#include <iostream>
 
 radeon_profile::radeon_profile(QStringList a,QWidget *parent) :
     QMainWindow(parent),
@@ -355,11 +356,11 @@ void radeon_profile::adjustFanSpeed() {
         }
 
         // find bounds of current temperature
-        const QMap<int,unsigned int>::const_iterator high = currentFanProfile.upperBound(device.gpuTemeperatureData.current),
-                low = high - 1;
+        QMap<int,unsigned int>::iterator high = currentFanProfile.upperBound(device.gpuTemeperatureData.current);
+        QMap<int,unsigned int>::iterator low = (currentFanProfile.size() > 1 ? high - 1 : high);
 
         int hSpeed = high.value(),
-                lSpeed = low.value();
+			lSpeed = low.value();
 
         if (high == currentFanProfile.constBegin()) {
             device.setPwmValue(device.features.pwmMaxSpeed * hSpeed / 100);


### PR DESCRIPTION
Probably not the right fix, but I hope it is helpful. This was crashing on my system (Arch Linux) with an apparently troubled RX 480 that has no existing fan speed profile data. 'low = high - 1' assumes more than 1 element in the QMap, which was not the case on my system. Now everything works well for me and radeon-profile is able to recall my profiles without seg faulting.