### PR TITLE
Improve rp-dev

### DIFF
--- a/radeon-profile/components/pieprogressbar.h
+++ b/radeon-profile/components/pieprogressbar.h
@@ -9,6 +9,8 @@
 #include "globalStuff.h"
 #include "ui_pieprogressbar.h"
 
+using namespace QtCharts;
+
 namespace Ui {
 class PieProgressBar;
 }

--- a/radeon-profile/components/rpplot.h
+++ b/radeon-profile/components/rpplot.h
@@ -9,6 +9,8 @@
 #include "globalStuff.h"
 #include <QDebug>
 
+using namespace QtCharts;
+
 class PlotManager;
 class RPPlot;
 

--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -555,7 +555,7 @@ GPUPwmStruct dXorg::getPwmSpeed() {
 
     QFile f(hwmonAttributes.pwm1);
 
-    if (f.open(QIODevice::ReadOnly)) {
+    if (f.exists() && f.open(QIODevice::ReadOnly)) {
        tmp.pwmSpeed = QString(f.readLine(4)).toInt();
        f.close();
     }

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -13,6 +13,7 @@
 #include <QList>
 #include <QTreeWidgetItem>
 #include <QSharedMemory>
+#include <QFile>
 
 
 #define SHARED_MEM_SIZE 128

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -134,7 +134,7 @@ struct GPUUsageStruct {
 };
 
 struct GPUConstParams {
-     int pwmMaxSpeed, maxCoreClock = -1, maxMemClock = -1;
+     int pwmMaxSpeed = -1, maxCoreClock = -1, maxMemClock = -1;
      long VRAMSize = -1;
 };
 

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -131,7 +131,7 @@ void gpu::defineAvailableDataContainer() {
 
     GPUPwmStruct tmpPWm = driverHandler->getPwmSpeed();
 
-    if (tmpPWm.pwmSpeed != -1)
+    if (tmpPWm.pwmSpeed != -1 && gpuParams.pwmMaxSpeed != -1)
         gpuData.insert(ValueID::FAN_SPEED_PERCENT, RPValue(ValueUnit::PERCENT, ((float)tmpPWm.pwmSpeed / gpuParams.pwmMaxSpeed ) * 100));
 
     if (tmpPWm.pwmSpeedRpm != -1)
@@ -255,7 +255,8 @@ void gpu::setForcePowerLevel(ForcePowerLevels _newForcePowerLevel) {
 }
 
 void gpu::setPwmValue(unsigned int value) {
-    driverHandler->setPwmValue(gpuParams.pwmMaxSpeed * value / 100);
+    if(gpuParams.pwmMaxSpeed != -1)
+        driverHandler->setPwmValue(gpuParams.pwmMaxSpeed * value / 100);
 }
 
 void gpu::setPwmManualControl(bool manual) {
@@ -265,7 +266,8 @@ void gpu::setPwmManualControl(bool manual) {
 void gpu::getPwmSpeed() {
     GPUPwmStruct tmp = driverHandler->getPwmSpeed();
 
-    gpuData.insert(ValueID::FAN_SPEED_PERCENT, RPValue(ValueUnit::PERCENT, ((float)tmp.pwmSpeed / gpuParams.pwmMaxSpeed ) * 100));
+    if(gpuParams.pwmMaxSpeed != -1)
+        gpuData.insert(ValueID::FAN_SPEED_PERCENT, RPValue(ValueUnit::PERCENT, ((float)tmp.pwmSpeed / gpuParams.pwmMaxSpeed ) * 100));
     gpuData.insert(ValueID::FAN_SPEED_RPM, RPValue(ValueUnit::RPM, tmp.pwmSpeedRpm));
 }
 

--- a/radeon-profile/ioctlHandler.cpp
+++ b/radeon-profile/ioctlHandler.cpp
@@ -98,8 +98,8 @@ ioctlHandler::~ioctlHandler(){
 bool ioctlHandler::getGpuUsage(float *data, int time, int frequency) const {
 #define ONE_SECOND 1000000
     const unsigned int sleep = ONE_SECOND/frequency;
-    unsigned int slept, activeCount = 0, totalCount = 0;
-    for(slept = 0; slept < time; usleep(sleep), slept+=sleep, totalCount++){
+    unsigned int activeCount = 0, totalCount = 0;
+    for(int slept = 0; slept < time; usleep(sleep), slept+=sleep, totalCount++){
         bool active;
         if(!isCardActive(&active))
             return false; // Read failed, exit

--- a/radeon-profile/ioctl_amdgpu.cpp
+++ b/radeon-profile/ioctl_amdgpu.cpp
@@ -77,7 +77,8 @@ bool amdgpuIoctlHandler::getCoreClock(int *data) const {
 #ifdef AMDGPU_INFO_SENSOR_GFX_SCLK
     return getSensorValue(data, sizeof(data), AMDGPU_INFO_SENSOR_GFX_SCLK);
 #else
-    return getClocks(data, NULL);
+    Q_UNUSED(data);
+    return false;
 #endif
 }
 
@@ -114,7 +115,8 @@ bool amdgpuIoctlHandler::getMemoryClock(int *data) const {
 #ifdef  AMDGPU_INFO_SENSOR_GFX_MCLK
     return getSensorValue(data, sizeof(data), AMDGPU_INFO_SENSOR_GFX_MCLK);
 #else
-    return getClocks(NULL, data);
+    Q_UNUSED(data);
+    return false;
 #endif
 }
 

--- a/radeon-profile/ioctl_amdgpu.cpp
+++ b/radeon-profile/ioctl_amdgpu.cpp
@@ -34,7 +34,7 @@ bool amdgpuIoctlHandler::getSensorValue(void *data, unsigned dataSize, unsigned 
 
 
 /**
- * @see https://cgit.freedesktop.org/mesa/drm/tree/include/drm/amdgpu_drm.h#n437
+ * @see https://cgit.freedesktop.org/mesa/drm/tree/include/drm/amdgpu_drm.h#n535
  * @see https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/include/uapi/drm/amdgpu_drm.h#n471
  */
 bool amdgpuIoctlHandler::getValue(void *data, unsigned dataSize, unsigned command) const {
@@ -77,8 +77,7 @@ bool amdgpuIoctlHandler::getCoreClock(int *data) const {
 #ifdef AMDGPU_INFO_SENSOR_GFX_SCLK
     return getSensorValue(data, sizeof(data), AMDGPU_INFO_SENSOR_GFX_SCLK);
 #else
-    Q_UNUSED(data);
-    return false;
+    return getClocks(data, NULL);
 #endif
 }
 
@@ -115,8 +114,7 @@ bool amdgpuIoctlHandler::getMemoryClock(int *data) const {
 #ifdef  AMDGPU_INFO_SENSOR_GFX_MCLK
     return getSensorValue(data, sizeof(data), AMDGPU_INFO_SENSOR_GFX_MCLK);
 #else
-    Q_UNUSED(data);
-    return false;
+    return getClocks(NULL, data);
 #endif
 }
 

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -268,7 +268,6 @@
        <zorder>btn_dpmPerformance</zorder>
        <zorder>combo_pLevel</zorder>
        <zorder>btn_fanControl</zorder>
-       <zorder>verticalSpacer_5</zorder>
       </widget>
       <widget class="QWidget" name="pageProfile">
        <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1084,7 +1083,6 @@
                  </item>
                 </layout>
                 <zorder>cb_plotsRightGap</zorder>
-                <zorder>verticalSpacer_7</zorder>
                </widget>
               </item>
               <item row="5" column="3">


### PR DESCRIPTION
Fix build where objects in namespace QtCharts were not found.
Check if pwmMaxSpeed is available before using it to calculate fan speed.
Remove very verbose runtime warning by checking if pwm file exists before opening it.
If AMDGPU_INFO_SENSOR is not available use AMDGPU_INFO_VCE_CLOCK_TABLE as fallback.
Fix typo.