### PR TITLE
Fix build if AMDGPU_INFO_SENSOR is not supported

### DIFF
--- a/radeon-profile/components/topbarcomponents.h
+++ b/radeon-profile/components/topbarcomponents.h
@@ -18,7 +18,7 @@ class TopbarItem {
 public:
     virtual void updateItemValue(const GPUDataContainer &data) = 0;
     virtual void setPrimaryColor(const QColor &c) = 0;
-    virtual void setSecondaryColor(const QColor &c) { }
+    virtual void setSecondaryColor(const QColor &c) { Q_UNUSED(c); }
     virtual void setSecondaryValueId(const ValueID vId) {
         secondaryValueId = vId;
         secondaryValueIdEnabled = true;

--- a/radeon-profile/ioctl_amdgpu.cpp
+++ b/radeon-profile/ioctl_amdgpu.cpp
@@ -26,7 +26,7 @@ bool amdgpuIoctlHandler::getSensorValue(void *data, unsigned dataSize, unsigned 
     return success;
 #else
     Q_UNUSED(data);
-    Q_UNUSED(command);
+    Q_UNUSED(sensor);
     Q_UNUSED(dataSize);
     return false;
 #endif

--- a/radeon-profile/ioctl_amdgpu.cpp
+++ b/radeon-profile/ioctl_amdgpu.cpp
@@ -14,7 +14,7 @@
 amdgpuIoctlHandler::amdgpuIoctlHandler(unsigned cardIndex) : ioctlHandler(cardIndex) { }
 
 bool amdgpuIoctlHandler::getSensorValue(void *data, unsigned dataSize, unsigned sensor) const {
-#ifdef DRM_IOCTL_AMDGPU_INFO
+#if defined(DRM_IOCTL_AMDGPU_INFO) && defined(AMDGPU_INFO_SENSOR)
     struct drm_amdgpu_info buffer = {};
     buffer.query = AMDGPU_INFO_SENSOR;
     buffer.return_pointer = reinterpret_cast<uint64_t>(data);


### PR DESCRIPTION
If libdrm defines DRM_IOCTL_AMDGPU_INFO but not AMDGPU_INFO_SENSOR [the compilation fails in ioctl_amdgpu.cpp, line 19](https://build.opensuse.org/package/live_build_log/home:danysan95/radeon-profile/Fedora_25/x86_64). This fix checks if AMDGPU_INFO_SENSOR is defined and solves the problem.