### PR TITLE
Fixed backwards `greater than or equals to` markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Fan control is available only on Radeon HD 7000 series and above.
 
 # Dependencies
 
-* Qt 5.6<= (qt5-base and qt5-charts)
+* Qt >= 5.6 (qt5-base and qt5-charts)
 * libxrandr
-* libdrm (for amdgpu, 2.4.79<=, more recent, the better)
-* recent kernel (for amdgpu 4.12<=, more recent, the better)
+* libdrm (for amdgpu, >= 2.4.79, more recent, the better)
+* recent kernel (for amdgpu >= 4.12, more recent, the better)
 * radeon card
 
 For full functionality:


### PR DESCRIPTION
The way they were before looked like `lesser than or equals to`.