### PR TITLE
Fix segfault caused by timer initialization

### DIFF
--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -53,6 +53,11 @@ radeon_profile::radeon_profile(QWidget *parent) :
     // create runtime stuff, setup rest of ui
     setupUiElements();
 
+    // timer init
+    timer = new QTimer(this);
+    timer->setInterval(ui->spin_timerInterval->value() * 1000);
+
+    // load settings from configuration file
     loadConfig();
 
     if (!device.initialize()) {
@@ -77,9 +82,6 @@ radeon_profile::radeon_profile(QWidget *parent) :
     fillConnectors();
     fillModInfo();
 
-    // timer init
-    timer = new QTimer(this);
-    timer->setInterval(ui->spin_timerInterval->value() * 1000);
     timer->start();
 
     showWindow();

--- a/radeon-profile/uiEvents.cpp
+++ b/radeon-profile/uiEvents.cpp
@@ -175,7 +175,11 @@ void radeon_profile::closeFromTray() {
 
 void radeon_profile::on_spin_timerInterval_valueChanged(double arg1)
 {
-    timer->setInterval(arg1*1000);
+    if(timer != nullptr){
+        qDebug() << "Setting timer interval to " << arg1;
+        timer->setInterval(arg1*1000);
+    } else
+        qCritical() << "on_spin_timerInterval_valueChanged: timer is not initialized";
 }
 
 void radeon_profile::refreshBtnClicked() {


### PR DESCRIPTION
Prevents on_spin_timerInterval_valueChanged() from setting the interval on a null timer.
Fixes issue https://github.com/marazmista/radeon-profile/issues/75 .