### PR TITLE
Clear R.P. currentGPUData List before creating Data List items

### DIFF
--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -336,6 +336,7 @@ void radeon_profile::refreshUI() {
 
 void radeon_profile::createCurrentGpuDataListItems()
 {
+    ui->list_currentGPUData->clear();
     for (int i = 0; i < device.gpuData.keys().count(); ++i) {
 
         // exclude before current from list


### PR DESCRIPTION
Add call to clear method to RadeonProfile::createCurrentGpuDataListItems, before proceding with creating and adding Data.

This prevents the list of entries from growing each time the currentGPU gets switched.
This is how it currently looks like after switching once.
![radeon_profile_list_currentgpudata_buildup](https://user-images.githubusercontent.com/7819429/44176530-77f2ea80-a0ea-11e8-82e1-9c49dcc6b765.png)


This might not be the best Fix or place for clearing the list, though it's the one i could find.