### PR TITLE
Specify full socket path for daemon

### DIFF
--- a/radeon-profile/daemonComm.cpp
+++ b/radeon-profile/daemonComm.cpp
@@ -16,7 +16,7 @@ daemonComm::~daemonComm() {
 void daemonComm::connectToDaemon() {
     qDebug() << "Connecting to daemon";
     signalSender->abort();
-    signalSender->connectToServer("radeon-profile-daemon-server");
+    signalSender->connectToServer("/tmp/radeon-profile-daemon-server");
 }
 
 void daemonComm::sendCommand(const QString command) {


### PR DESCRIPTION
Ran radeon-profile with strace:
```
connect(21, {sa_family=AF_UNIX, sun_path="/tmp/orestis/radeon-profile-daemon-server"}, 110) = -1 ENOENT (No such file or directory)
```
The socket path on my machine defaults to `/tmp/[username]/…` instead of
`/tmp/…`

radeon-profile-daemon-server explicitly specifies `/tmp/radeon-profile-daemon-server` as the socket path (https://github.com/marazmista/radeon-profile-daemon/blob/0b56fb08878ef5cac976214a3e0aa7285443c6bd/radeon-profile-daemon/rpdthread.cpp#L22), so I changed the radeon-profile code to use the full path as well.