### PR TITLE
Change default config location to ~/.config. (Fixes #99)

### DIFF
--- a/radeon-profile/radeon_profile.h
+++ b/radeon-profile/radeon_profile.h
@@ -150,7 +150,6 @@ private:
     QTimer *timer = nullptr;
 
     gpu device;
-    static const QString settingsPath;
     QList<ExecBin*> execsRunning;
     FanProfileSteps currentFanProfile;
     QMap<QString, FanProfileSteps> fanProfiles;


### PR DESCRIPTION
As discussed, this PR migrates the config files over to the distro's config dir.  It behaves like this:

For loading: 
* Try to load settings from config dir (`~/.config/radeon-profile`) 
* * If that fails, try to load settings from the old location (`~/`)

For saving:
* Always save to the config dir
* * If settings were loaded from the old location, these old files will then be removed

I'm using `QStandardPaths::ConfigLocation` to query the config dir. It will return `~/config` unless `XDG_CONFIG_HOME` is set to something else, so it fits perfectly here.