### PR TITLE
Fix GPU usage with AMDGPU

### DIFF
--- a/radeon-profile/ioctl_amdgpu.cpp
+++ b/radeon-profile/ioctl_amdgpu.cpp
@@ -57,7 +57,8 @@ bool amdgpuIoctlHandler::getValue(void *data, unsigned dataSize, unsigned comman
 
 bool amdgpuIoctlHandler::getGpuUsage(float *data) const {
 #ifdef AMDGPU_INFO_SENSOR_GPU_LOAD
-    return getSensorValue(data, sizeof(data), AMDGPU_INFO_SENSOR_GPU_LOAD);
+    int *tmp = reinterpret_cast<int*>(data);
+    return getSensorValue(&tmp, sizeof(tmp), AMDGPU_INFO_SENSOR_GPU_LOAD);
 #else
     Q_UNUSED(data);
     return false;


### PR DESCRIPTION
As reminder, the bug is `radeon-profile` shows 0% for GPU usage with AMDGPU:
![radeon-profile-before](https://user-images.githubusercontent.com/2873785/51793486-7e20e300-21c1-11e9-9fe9-cdeef6757952.png)

According to amdgpu source code, `AMDGPU_INFO_SENSOR_GPU_LOAD` is an integer:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/gpu/drm/amd/amdgpu/amdgpu_kms.c#n854

In `getSensorValue()`, data (a `float*`) is casted as `uint64_t`, and value is incorrect due to cast.
Otherwise, `amdgpuIoctlHandler::getGpuUsage()` parameter type cannot be changed because of `radeonIoctlHandler::getGpuUsage()`, who is really a floating value.

So, we need to pass integer to `getSensorValue()` and keep float in `getGpuUsage()`. Using a temporary variable to cast `data` as an integer seems to be a good compromise.

With this patch, GPU usage is reported as expected:
![radeon-profile-after](https://user-images.githubusercontent.com/2873785/51793485-7e20e300-21c1-11e9-8750-3fa5ed11bc3d.png)
This PR fixes #70.