### PR TITLE
Fix typo in function name refreshPopwerPlayTables

### DIFF
--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -643,7 +643,7 @@ void dXorg::figureOutDriverFeatures() {
     features.isPercentCoreOcAvailable = !driverFiles.sysFs.pp_sclk_od.isEmpty();
     features.isPercentMemOcAvailable = !driverFiles.sysFs.pp_mclk_od.isEmpty();
 
-    refreshPopwerPlayTables();
+    refreshPowerPlayTables();
     features.isDpmCoreFreqTableAvailable = features.sclkTable.count() > 0;
     features.isDpmMemFreqTableAvailable = features.mclkTable.count() > 0;
 
@@ -658,7 +658,7 @@ void dXorg::figureOutDriverFeatures() {
     }
 }
 
-void dXorg::refreshPopwerPlayTables()
+void dXorg::refreshPowerPlayTables()
 {
     if (!driverFiles.sysFs.pp_dpm_sclk.isEmpty())
         features.sclkTable = loadPowerPlayTable(driverFiles.sysFs.pp_dpm_sclk);

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -90,7 +90,7 @@ public:
     void readOcTableAndRanges();
     void setOcTable(const QString &tableType, const FVTable &table);
     InitializationConfig getInitConfig();
-    void refreshPopwerPlayTables();
+    void refreshPowerPlayTables();
     
 private:
     QChar gpuSysIndex;

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -341,7 +341,7 @@ int gpu::getCurrentPowerPlayTableId(const QString &file) {
 }
 
 void gpu::refreshPowerPlayTables() {
-    driverHandler->refreshPopwerPlayTables();
+    driverHandler->refreshPowerPlayTables();
 }
 
 void gpu::getPowerCapSelected() {
@@ -947,4 +947,3 @@ QList<QTreeWidgetItem *> gpu::getCardConnectors() const {
 
     return cardConnectorsList;
 }
-


### PR DESCRIPTION
I am not sure, but I think `Popwer` should be replaced with `Power`.