### PR TITLE
Allow tray icon to be themed

### DIFF
--- a/radeon-profile/uiElements.cpp
+++ b/radeon-profile/uiElements.cpp
@@ -42,7 +42,7 @@ void radeon_profile::setupTrayIcon() {
     menu_tray->addAction(closeApp);
 
     // setup icon finally //
-    QIcon appicon(":/icon/extra/radeon-profile.png");
+    QIcon appicon = QIcon::fromTheme("radeon-profile-tray", QIcon(":/icon/extra/radeon-profile.png"));
     icon_tray = new QSystemTrayIcon(appicon,this);
     icon_tray->show();
     icon_tray->setContextMenu(menu_tray);


### PR DESCRIPTION
This change makes the app use the themed icon `radeon-profile-tray` if available, with a fallback on the current hardcoded icon.

Before (or without an available icon in your theme):
![image](https://user-images.githubusercontent.com/237337/82889088-840c0d00-9f4a-11ea-9541-0f4e879bd0a3.png)

After (using a custom icon I made):
![image](https://user-images.githubusercontent.com/237337/82889134-9423ec80-9f4a-11ea-8394-97225458a9cb.png)
