### PR TITLE
Add workaround for marazmista/radeon-profile#151

### DIFF
--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -269,7 +269,7 @@ void gpu::setPwmValue(unsigned int value) {
     // disabled (by the OS..?) and that we have to re-enable it, if needed,
     // after returning from sleep
     static QFile pwmEnableFile(getDriverFiles().hwmonAttributes.pwm1_enable);
-    if (Q_UNLIKELY(pwmEnabled && pwmEnableFile.open(QFile::ReadOnly)
+    if (Q_UNLIKELY(pwmEnableFile.open(QFile::ReadOnly)
                    && !pwmEnableFile.read(1).contains(pwm_manual)))
     {
         setPwmManualControl(true);
@@ -282,7 +282,6 @@ void gpu::setPwmValue(unsigned int value) {
 
 void gpu::setPwmManualControl(bool manual) {
     driverHandler->setNewValue(getDriverFiles().hwmonAttributes.pwm1_enable, QString(manual ? pwm_manual : pwm_auto));
-    pwmEnabled = manual;
 }
 
 void gpu::getFanSpeed() {

--- a/radeon-profile/gpu.h
+++ b/radeon-profile/gpu.h
@@ -31,7 +31,6 @@ public:
 
     char currentGpuIndex;
     QString currentPowerProfile, currentPowerLevel;
-    bool pwmEnabled = false;
 
     QList<QTreeWidgetItem *> getCardConnectors() const;
     QStringList getGLXInfo(QString gpuName) const;

--- a/radeon-profile/gpu.h
+++ b/radeon-profile/gpu.h
@@ -31,6 +31,7 @@ public:
 
     char currentGpuIndex;
     QString currentPowerProfile, currentPowerLevel;
+    bool pwmEnabled = false;
 
     QList<QTreeWidgetItem *> getCardConnectors() const;
     QStringList getGLXInfo(QString gpuName) const;


### PR DESCRIPTION
If the PC returns from sleep/hibernation we can enforce restoration of
the correct fan control mode by checking if the correct value is set for
pwm_enable and restore the value if necessary