### PR TITLE
Fix typo and redudant dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install and run radeon-profile-daemon (https://github.com/marazmista/radeon-prof
 
 # Dependencies
 
-* Qt 5.6<= (qt5-base and qt5-charts) (qt5-defaults, libqt5charts5, libqt5charts5-dev for Ubuntu/Debian)
+* Qt 5.6<= (qt5-base and qt5-charts) (On Debian/Ubuntu: `qt5-default libqt5charts5-dev`)
 * libxrandr
 * libdrm (for amdgpu, 2.4.79<=, more recent, the better)
 * recent kernel (for amdgpu 4.12<=, more recent, the better)


### PR DESCRIPTION
default, not detauls. installing -dev is sufficient to pull the libraries too.