### PR TITLE
Remove qt5-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install and run radeon-profile-daemon (https://github.com/marazmista/radeon-prof
 
 # Dependencies
 
-* Qt 5.6<= (qt5-base and qt5-charts) (On Debian/Ubuntu: `qt5-default libqt5charts5-dev`)
+* Qt 5.6<= (qt5-base and qt5-charts) (On Debian/Ubuntu: `libqt5charts5-dev`)
 * libxrandr
 * libdrm (for amdgpu, 2.4.79<=, more recent, the better)
 * recent kernel (for amdgpu 4.12<=, more recent, the better)


### PR DESCRIPTION
Actually qt5-default is not really needed.

In fact it is now removed from Debian testing / unstable:

https://tracker.debian.org/news/1187732/accepted-qtbase-opensource-src-5151dfsg-2-source-into-unstable/

Installing `libqt5charts5-dev` is enough, because it depends on `qtbase5-dev`, and it depends on `qtchooser` (which provides qmake).