### PR TITLE
fix: Categories in radeon-profile.desktop

### DIFF
--- a/radeon-profile/extra/radeon-profile.desktop
+++ b/radeon-profile/extra/radeon-profile.desktop
@@ -6,5 +6,5 @@ Exec=radeon-profile
 Icon=radeon-profile
 Terminal=false
 Type=Application
-Categories=System;Monitor;HardwareSettings;TrayIcon;
+Categories=System;Monitor;Settings;HardwareSettings;
 StartupNotify=false


### PR DESCRIPTION
[desktop-file-validate](https://www.freedesktop.org/wiki/Software/desktop-file-utils/) tool consider as error current state of `TrayIcon`. This is should be fixed since this mandatory to pass all this kind of desktop-file-validate complaints and packaging for official repos.

```ini
radeon-profile.desktop: hint: value item "HardwareSettings" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Settings
radeon-profile.desktop: error: value item "TrayIcon" in key "Categories" in group "Desktop Entry" is a reserved category, so a "OnlyShowIn" key must be included
```

https://specifications.freedesktop.org/menu-spec/menu-spec-1.0.html#category-registry

Also one warn and could fixed by adding one parent category - `Settings`.