### PR TITLE
docs: Add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ sudo apt install radeon-profile
 ### Arch Linux
 * AUR package: https://aur.archlinux.org/packages/radeon-profile-git/
 * System daemon AUR package: https://aur.archlinux.org/packages/radeon-profile-daemon-git/
+
+### Fedora
+Available in official Fedora [repository](https://src.fedoraproject.org/rpms/radeon-profile).
+```
+sudo dnf install radeon-profile
+```
 # Links
 
 * System daemon: https://github.com/marazmista/radeon-profile-daemon


### PR DESCRIPTION
Packaged for Fedora repos. Now [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2021-eba7681ea2).