### PR TITLE
handle null chars in dxorg.cpp:getValueFromSysFsFile()

### DIFF
--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -61,7 +61,7 @@ QString getValueFromSysFsFile(QString fileName) {
     QString value("-1");
 
     if (f.open(QIODevice::ReadOnly))
-        value = QString(f.readAll()).trimmed();
+        value = QString(f.readAll().replace('\0', "")).trimmed();
 
     f.close();
     return value;


### PR DESCRIPTION
QString truncates strings after the first null character. If a sysfs file contains null chars in the middle of its contents, the output of getValueFromSysFsFile() is incomplete.

This fix replaces all occurrences of null chars in the QByteArray returned from QFile::readAll() before converting it to a QString.

This fixes segfaults on startup when incomplete pp_od_clk_voltage tables are being parsed (#279).