### PR TITLE
Add bounds check to move left/right buttons in topbar cfg dialog

### DIFF
--- a/radeon-profile/dialogs/dialog_topbarcfg.cpp
+++ b/radeon-profile/dialogs/dialog_topbarcfg.cpp
@@ -45,6 +45,9 @@ void Dialog_topbarCfg::on_btn_cancel_clicked()
 
 void Dialog_topbarCfg::on_btn_moveLeft_clicked()
 {
+    if (ui->listWidget->currentRow() <= 0)
+        return;
+
     int a = ui->listWidget->currentRow() == ui->listWidget->count() - 1 ? 0 : 1;
 
     schemas.insert(ui->listWidget->currentRow() - 1, schemas.takeAt(ui->listWidget->currentRow()));
@@ -54,6 +57,10 @@ void Dialog_topbarCfg::on_btn_moveLeft_clicked()
 
 void Dialog_topbarCfg::on_btn_moveRight_clicked()
 {
+    if ((ui->listWidget->currentRow() == -1) ||
+        (ui->listWidget->currentRow() == ui->listWidget->count() - 1))
+        return;
+
     schemas.insert(ui->listWidget->currentRow() + 1, schemas.takeAt(ui->listWidget->currentRow()));
     ui->listWidget->insertItem(ui->listWidget->currentRow() + 1, ui->listWidget->takeItem(ui->listWidget->currentRow()));
     ui->listWidget->setCurrentRow(ui->listWidget->currentRow() + 1);


### PR DESCRIPTION
Make sure an item is actually selected and can be moved in the desired direction. I.e. don't try to move left if it is already the first item and don't move right if it is the last.

Without this bounds check clicking on move left/right in those situations leads to crashes due to out of range acccesses on ui->listWidget.