### PR TITLE
feature: support for multiple temperature sensors

### DIFF
--- a/radeon-profile/components/topbarcomponents.h
+++ b/radeon-profile/components/topbarcomponents.h
@@ -263,8 +263,23 @@ public:
             addSchema(tis);
         }
 
-        if (availableData.contains(ValueID::TEMPERATURE_CURRENT)) {
-            TopbarItemDefinitionSchema tis(ValueID::TEMPERATURE_CURRENT, TopbarItemType::LARGE_LABEL, defaultForeground);
+        const ValueID t_edge = ValueID(ValueID::TEMPERATURE_CURRENT, ValueID::T_EDGE);
+        if (availableData.contains(t_edge)) {
+            TopbarItemDefinitionSchema tis(t_edge, TopbarItemType::LARGE_LABEL, defaultForeground);
+            addSchema(tis);
+        }
+
+        const ValueID t_junction = ValueID(ValueID::TEMPERATURE_CURRENT, ValueID::T_JUNCTION);
+        const ValueID t_mem = ValueID(ValueID::TEMPERATURE_CURRENT, ValueID::T_MEM);
+        if (availableData.contains(t_junction)) {
+            TopbarItemDefinitionSchema tis(t_junction, TopbarItemType::LABEL_PAIR, defaultForeground);
+            if (availableData.contains(t_mem)) {
+                tis.setSecondaryValueId(t_mem);
+                tis.setSecondaryColor(defaultForeground);
+            }
+            addSchema(tis);
+        } else if (availableData.contains(t_mem)) {
+            TopbarItemDefinitionSchema tis(t_mem, TopbarItemType::LABEL_PAIR, defaultForeground);
             addSchema(tis);
         }
 

--- a/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
+++ b/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
@@ -79,7 +79,7 @@ void Dialog_deineTopbarItem::createCombo(QComboBox *combo, const TopbarItemType 
                 if (availableGpuData->at(i) == ValueID::CLK_MEM && gpuParams->maxMemClock != -1)
                     combo->addItem(globalStuff::getNameOfValueID(ValueID::CLK_MEM), QVariant::fromValue(ValueID::CLK_MEM));
 
-                if (availableGpuData->at(i) == ValueID::TEMPERATURE_CURRENT && gpuParams->temp1_crit != -1)
+                if (availableGpuData->at(i) == ValueID::TEMPERATURE_CURRENT && gpuParams->temp_crit[0] != -1)
                     combo->addItem(globalStuff::getNameOfValueID(ValueID::TEMPERATURE_CURRENT), QVariant::fromValue(ValueID::TEMPERATURE_CURRENT));
 
             }

--- a/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
+++ b/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
@@ -166,7 +166,7 @@ void Dialog_deineTopbarItem::on_combo_primaryData_currentIndexChanged(int index)
     ui->combo_secondaryData->clear();
     ui->combo_secondaryData->addItem("");
 
-    switch (static_cast<ValueID>(ui->combo_primaryData->currentData().toInt())) {
+    switch (ui->combo_primaryData->currentData().value<ValueID>()) {
         case ValueID::FAN_SPEED_PERCENT:
             if (availableGpuData->contains(ValueID::FAN_SPEED_RPM))
                 ui->combo_secondaryData->addItem(globalStuff::getNameOfValueID(ValueID::FAN_SPEED_RPM), QVariant::fromValue(ValueID::FAN_SPEED_RPM));
@@ -191,16 +191,16 @@ void Dialog_deineTopbarItem::on_btn_cancel_clicked()
 
 void Dialog_deineTopbarItem::on_btn_save_clicked()
 {
-    editedSchema = TopbarItemDefinitionSchema(static_cast<ValueID>(ui->combo_primaryData->currentData().toInt()),
+    editedSchema = TopbarItemDefinitionSchema(ui->combo_primaryData->currentData().value<ValueID>(),
                                               getItemType(), ui->frame_primaryColor->palette().background().color());
 
     if (!ui->combo_secondaryData->currentText().isEmpty() && ui->combo_secondaryData->isEnabled()) {
-        editedSchema.setSecondaryValueId(static_cast<ValueID>(ui->combo_secondaryData->currentData().toInt()));
+        editedSchema.setSecondaryValueId(ui->combo_secondaryData->currentData().value<ValueID>());
         editedSchema.setSecondaryColor(ui->frame_secondaryColor->palette().background().color());
     }
 
     if (ui->radio_pie->isChecked()) {
-        switch (static_cast<ValueID>(ui->combo_primaryData->currentData().toInt())) {
+        switch (ui->combo_primaryData->currentData().value<ValueID>()) {
             case ValueID::CLK_CORE:
                 editedSchema.pieMaxValue = gpuParams->maxCoreClock;
                 break;

--- a/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
+++ b/radeon-profile/dialogs/dialog_deinetopbaritem.cpp
@@ -60,28 +60,27 @@ void Dialog_deineTopbarItem::createCombo(QComboBox *combo, const TopbarItemType 
     switch (type) {
         case TopbarItemType::LABEL_PAIR:
         case TopbarItemType::LARGE_LABEL:
-            for (int i = 0; i < availableGpuData->count(); ++i) {
-                if (availableGpuData->at(i) == ValueID::TEMPERATURE_BEFORE_CURRENT)
+            for (const ValueID id : *availableGpuData) {
+                if (id == ValueID::TEMPERATURE_BEFORE_CURRENT)
                     continue;
 
-                combo->addItem(globalStuff::getNameOfValueID(availableGpuData->at(i)), QVariant::fromValue(availableGpuData->at(i)));
+                combo->addItem(globalStuff::getNameOfValueID(id), QVariant::fromValue(id));
             }
             break;
 
         case TopbarItemType::PIE:
-            for (int i = 0; i < availableGpuData->count(); ++i) {
-                if (globalStuff::getUnitFomValueId(availableGpuData->at(i)) == ValueUnit::PERCENT)
-                    combo->addItem(globalStuff::getNameOfValueID(availableGpuData->at(i)), QVariant::fromValue(availableGpuData->at(i)));
+            for (const ValueID id : *availableGpuData) {
+                if (globalStuff::getUnitFomValueId(id) == ValueUnit::PERCENT)
+                    combo->addItem(globalStuff::getNameOfValueID(id), QVariant::fromValue(id));
 
-                if (availableGpuData->at(i) == ValueID::CLK_CORE && gpuParams->maxCoreClock != -1)
-                    combo->addItem(globalStuff::getNameOfValueID(ValueID::CLK_CORE), QVariant::fromValue(ValueID::CLK_CORE));
+                if (id == ValueID::CLK_CORE && gpuParams->maxCoreClock != -1)
+                    combo->addItem(globalStuff::getNameOfValueID(id), QVariant::fromValue(id));
 
-                if (availableGpuData->at(i) == ValueID::CLK_MEM && gpuParams->maxMemClock != -1)
-                    combo->addItem(globalStuff::getNameOfValueID(ValueID::CLK_MEM), QVariant::fromValue(ValueID::CLK_MEM));
+                if (id == ValueID::CLK_MEM && gpuParams->maxMemClock != -1)
+                    combo->addItem(globalStuff::getNameOfValueID(id), QVariant::fromValue(id));
 
-                if (availableGpuData->at(i) == ValueID::TEMPERATURE_CURRENT && gpuParams->temp_crit[0] != -1)
-                    combo->addItem(globalStuff::getNameOfValueID(ValueID::TEMPERATURE_CURRENT), QVariant::fromValue(ValueID::TEMPERATURE_CURRENT));
-
+                if (id == ValueID::TEMPERATURE_CURRENT)
+                    combo->addItem(globalStuff::getNameOfValueID(id), QVariant::fromValue(id));
             }
             break;
     }

--- a/radeon-profile/dialogs/dialog_rpevent.cpp
+++ b/radeon-profile/dialogs/dialog_rpevent.cpp
@@ -19,6 +19,11 @@ Dialog_RPEvent::Dialog_RPEvent(QWidget *parent) :
 }
 
 void Dialog_RPEvent::setFeatures(const GPUDataContainer &gpuData, const DriverFeatures &features, const QList<QString> &profiles) {
+    for (const ValueID::Instance instance : features.tempSensors) {
+        const ValueID id(ValueID::TEMPERATURE_CURRENT, instance);
+        ui->combo_sensorInstance->addItem(globalStuff::getNameOfValueID(id), QVariant(instance));
+    }
+
     switch (features.currentPowerMethod) {
         case PowerMethod::DPM:
             ui->combo_powerLevelChange->addItems(globalStuff::createPowerLevelCombo(features.sysInfo.module));
@@ -72,6 +77,7 @@ void Dialog_RPEvent::on_btn_save_clicked()
     switch (ui->combo_eventTrigger->currentIndex()) {
         case 0:
             createdEvent.type = RPEventType::TEMPERATURE;
+            createdEvent.sensorInstance = ui->combo_sensorInstance->currentData().value<ValueID::Instance>();
             break;
         case 1:
             createdEvent.type = RPEventType::BINARY;
@@ -109,6 +115,7 @@ void Dialog_RPEvent::setEditedEvent(const RPEvent &rpe) {
     createdEvent = rpe;
 
     ui->combo_eventTrigger->setCurrentIndex(rpe.type);
+    ui->combo_sensorInstance->setCurrentIndex(ui->combo_sensorInstance->findData(rpe.sensorInstance));
     ui->cb_enabled->setChecked(rpe.enabled);
     ui->edt_eventName->setText(rpe.name);
     ui->spin_tempActivate->setValue(rpe.activationTemperature);
@@ -127,6 +134,12 @@ void Dialog_RPEvent::setEditedEvent(const RPEvent &rpe) {
 void Dialog_RPEvent::on_combo_fanChange_currentIndexChanged(int index)
 {
     ui->spin_fixedFanSpeed->setVisible(index == 2);
+}
+
+void Dialog_RPEvent::on_combo_eventTrigger_currentIndexChanged(int index)
+{
+    ui->combo_sensorInstance->setVisible(index == 0);
+    ui->label_sensorInstance->setVisible(index == 0);
 }
 
 void Dialog_RPEvent::on_btn_setBinary_clicked()

--- a/radeon-profile/dialogs/dialog_rpevent.h
+++ b/radeon-profile/dialogs/dialog_rpevent.h
@@ -25,6 +25,7 @@ private slots:
     void on_btn_cancel_clicked();
     void on_btn_save_clicked();
     void on_combo_fanChange_currentIndexChanged(int index);
+    void on_combo_eventTrigger_currentIndexChanged(int index);
     void on_btn_setBinary_clicked();
 
 private:

--- a/radeon-profile/dialogs/dialog_rpevent.ui
+++ b/radeon-profile/dialogs/dialog_rpevent.ui
@@ -151,6 +151,17 @@
        </property>
       </widget>
      </item>
+     <item row="3" column="1">
+       <widget class="QComboBox" name="combo_sensorInstance">
+       </widget>
+     </item>
+     <item row="3" column="0">
+       <widget class="QLabel" name="label_sensorInstance">
+           <property name="text">
+             <string>Temperature Sensor</string>
+           </property>
+       </widget>
+     </item>
     </layout>
    </item>
    <item row="1" column="0" colspan="3">

--- a/radeon-profile/dxorg.cpp
+++ b/radeon-profile/dxorg.cpp
@@ -1,6 +1,7 @@
 ﻿// copyright marazmista @ 29.03.2014
 
 #include "dxorg.h"
+#include "globalStuff.h"
 #include "gpu.h"
 #include "radeon_profile.h"
 
@@ -273,13 +274,18 @@ GPUClocks dXorg::getClocksFromPmFile() {
     return clocksData;
 }
 
-float dXorg::getTemperature() {
+float dXorg::getTemperature(int hwmon_id) {
     QString temp;
 
     switch (features.currentTemperatureSensor) {
         case TemperatureSensor::SYSFS_HWMON:
         case TemperatureSensor::CARD_HWMON:
-            return getValueFromSysFsFile(driverFiles.hwmonAttributes.temp1).toFloat() / 1000;
+            if (hwmon_id < features.tempSensors.size()) {
+                return getValueFromSysFsFile(driverFiles.hwmonAttributes.temp[hwmon_id].input).toFloat() / 1000;
+            } else {
+                return -1;
+            }
+
         case TemperatureSensor::PCI_SENSOR: {
             QStringList out = globalStuff::grabSystemInfo("sensors");
             temp = out[sensorsGPUtempIndex+2].split(" ",QString::SkipEmptyParts)[1].remove("+").remove("C").remove("°");
@@ -327,16 +333,18 @@ PowerMethod dXorg::getPowerMethodFallback() {
 
 TemperatureSensor dXorg::getTemperatureSensor() {
 
-    // first method, try read temp from sysfs in card dir (path from figureOutGPUDataPaths())
-    QString tmpValue = getValueFromSysFsFile(driverFiles.hwmonAttributes.temp1);
-    if (!tmpValue.isEmpty() || tmpValue != "-1")
-        return TemperatureSensor::CARD_HWMON;
-    else {
-        // second method, try find in system hwmon dir for file labeled VGA_TEMP
-        driverFiles.hwmonAttributes.temp1 = findSysfsHwmonForGPU();
-        if (!driverFiles.hwmonAttributes.temp1.isEmpty())
-            return TemperatureSensor::SYSFS_HWMON;
+    // first method, read temp from sysfs in card dir (path from figureOutGPUDataPaths())
+    // This should work, if hwmonAttribtes.temp was populated.
 
+    if (!driverFiles.hwmonAttributes.temp.empty()) {
+        return TemperatureSensor::CARD_HWMON;
+    } else {
+        // second method, try find in system hwmon dir for file labeled VGA_TEMP
+        HwmonTempSensor sensor = findSysfsHwmonForGPU();
+        if (sensor) {
+            driverFiles.hwmonAttributes.temp.push_back(std::move(sensor));
+            return TemperatureSensor::SYSFS_HWMON;
+        }
         // if above fails, use lm_sensors
         QStringList out = globalStuff::grabSystemInfo("sensors");
         if (out.indexOf(QRegExp(features.sysInfo.driverModuleString+"-pci.+")) != -1) {
@@ -351,7 +359,7 @@ TemperatureSensor dXorg::getTemperatureSensor() {
     return TemperatureSensor::TS_UNKNOWN;
 }
 
-QString dXorg::findSysfsHwmonForGPU() {
+HwmonTempSensor dXorg::findSysfsHwmonForGPU() {
     QStringList hwmonDev = globalStuff::grabSystemInfo("ls /sys/class/hwmon/");
 
     for (int i = 0; i < hwmonDev.count(); i++) {
@@ -361,11 +369,15 @@ QString dXorg::findSysfsHwmonForGPU() {
             QString file("/sys/class/hwmon/"+hwmonDev[i]+"/device/"+temp[o]);
             QString s = getValueFromSysFsFile(file);
             if (!s.isEmpty() && s.contains("VGA_TEMP"))
-                return file.replace("label", "input");
+                return HwmonTempSensor(
+                    file.replace("label", "input"),
+                    file.replace("label", "crit"),
+                    file.replace("label", "emergency"),
+                    file);
         }
     }
 
-    return "";
+    return HwmonTempSensor();
 }
 
 QList<QTreeWidgetItem *> dXorg::getModuleInfo() {
@@ -629,6 +641,57 @@ void dXorg::figureOutDriverFeatures() {
 
     features.currentTemperatureSensor = getTemperatureSensor();
 
+    if ((features.currentTemperatureSensor == TemperatureSensor::SYSFS_HWMON) ||
+        (features.currentTemperatureSensor == TemperatureSensor::CARD_HWMON)) {
+        const auto num_sensors = driverFiles.hwmonAttributes.temp.size();
+
+        #ifdef QT_DEBUG
+        QStringList sensorLabels;
+        sensorLabels.reserve(num_sensors);
+        #endif
+
+        features.tempSensors.reserve(num_sensors);
+        int hwmon_id = 1;
+        for (const auto &sensor : driverFiles.hwmonAttributes.temp) {
+            QString label = getValueFromSysFsFile(sensor.label);
+            ValueID id(ValueID::TEMPERATURE_CURRENT);
+            if (label.isEmpty() || (label == "-1")) {
+                // use "tempX" as label, if we have no label for this sensor
+                const auto str_begin = sensor.label.lastIndexOf("/") + 1;
+                const auto str_end   = sensor.label.lastIndexOf("_");
+                label = sensor.label.mid(str_begin, str_end - str_begin);
+                id.instance = globalStuff::setCustomInstanceLabel(id, label);
+                qDebug() << "temp sensor at"
+                         << sensor.label.left(sensor.label.lastIndexOf("_"))
+                         << "has no label.";
+            } else if (label == "edge") {
+                id.instance = ValueID::T_EDGE;
+            } else if (label == "junction") {
+                id.instance = ValueID::T_JUNCTION;
+            } else if (label == "mem") {
+                id.instance = ValueID::T_MEM;
+            } else {
+                // unknown label: Use the label reported by the driver as UI label
+                id.instance = globalStuff::setCustomInstanceLabel(id, label);
+                qDebug() << "unknown temp sensor type detected:" << label;
+            }
+
+            features.tempSensors.push_back(id.instance);
+            #ifdef QT_DEBUG
+            sensorLabels.push_back(label);
+            #endif
+            hwmon_id++;
+        }
+        #ifdef QT_DEBUG
+        qDebug().noquote() << "detected" << num_sensors << "temperature sensors:"
+                           << sensorLabels.join(",");
+        #endif
+
+    } else {
+        // for any non hwmon temp reading, assume edge (instance == 0)
+        features.tempSensors.push_back(0);
+    }
+
     features.isFanControlAvailable = !driverFiles.hwmonAttributes.pwm1.isEmpty();
 
     features.isPercentCoreOcAvailable = !driverFiles.sysFs.pp_sclk_od.isEmpty();
@@ -681,9 +744,30 @@ void dXorg::figureOutConstParams() {
                  << "\n vram size: " << params.VRAMSize;
     }
 
-    if (!driverFiles.hwmonAttributes.temp1_crit.isEmpty())
-        params.temp1_crit = getValueFromSysFsFile(driverFiles.hwmonAttributes.temp1_crit).toInt() / 1000;
+    if ((features.currentTemperatureSensor == TemperatureSensor::SYSFS_HWMON) ||
+        (features.currentTemperatureSensor == TemperatureSensor::CARD_HWMON)) {
+        const auto num_sensors = driverFiles.hwmonAttributes.temp.size();
+        params.temp_crit.reserve(num_sensors);
+        params.temp_emergency.reserve(num_sensors);
+        for (int hwmon_id = 0; hwmon_id < num_sensors; hwmon_id++) {
+            const auto& sensor = driverFiles.hwmonAttributes.temp[hwmon_id];
+            const ValueID::Instance instance = features.tempSensors[hwmon_id];
 
+            const int crit = sensor.crit.isEmpty()
+                ? - 1
+                : getValueFromSysFsFile(sensor.crit).toInt() / 1000;
+
+            const int emergency = sensor.emergency.isEmpty()
+                ? - 1
+                : getValueFromSysFsFile(sensor.emergency).toInt() / 1000;
+
+            params.temp_crit.insert(instance, crit);
+            params.temp_emergency.insert(instance, emergency);
+        }
+    } else {
+        params.temp_crit.insert(0, -1);
+        params.temp_emergency.insert(0, -1);
+    }
 
     if (!driverFiles.hwmonAttributes.pwm1_max.isEmpty())
         params.pwmMaxSpeed = getValueFromSysFsFile(driverFiles.hwmonAttributes.pwm1_max).toInt();

--- a/radeon-profile/dxorg.h
+++ b/radeon-profile/dxorg.h
@@ -66,7 +66,7 @@ public:
     GPUClocks getClocksFromIoctl();
     GPUClocks getClocks();
 
-    float getTemperature();
+    float getTemperature(int sensor_id=0);
     GPUUsage getGPUUsage();
     GPUFanSpeed getFanSpeed();
 
@@ -106,7 +106,7 @@ private:
     ioctlHandler *ioctlHnd;
 
     QString getClocksRawData();
-    QString findSysfsHwmonForGPU();
+    HwmonTempSensor findSysfsHwmonForGPU();
     PowerMethod getPowerMethodFallback();
     TemperatureSensor getTemperatureSensor();
     QString findSysFsHwmonForGpu();

--- a/radeon-profile/globalStuff.cpp
+++ b/radeon-profile/globalStuff.cpp
@@ -1,0 +1,4 @@
+#include "globalStuff.h"
+
+QHash<ValueID, QString> globalStuff::customInstanceLabels;
+

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -306,6 +306,20 @@ struct OCProfile {
     MapFVTables tables;
 };
 
+struct FanProfile {
+    FanProfileSteps steps;
+    int hysteresis = 0;
+
+    FanProfile() = default;
+
+    FanProfile(const FanProfileSteps& fp_steps,
+               int fp_hysteresis = 0)
+        : steps(fp_steps),
+          hysteresis(fp_hysteresis)
+    {
+    }
+};
+
 // structure which holds what can be display on ui and on its base
 // we enable ui elements
 struct DriverFeatures {

--- a/radeon-profile/globalStuff.h
+++ b/radeon-profile/globalStuff.h
@@ -309,13 +309,16 @@ struct OCProfile {
 struct FanProfile {
     FanProfileSteps steps;
     int hysteresis = 0;
+    ValueID::Instance sensor = ValueID::T_EDGE;
 
     FanProfile() = default;
 
     FanProfile(const FanProfileSteps& fp_steps,
-               int fp_hysteresis = 0)
+               int fp_hysteresis = 0,
+               ValueID::Instance fp_sensor = ValueID::T_EDGE)
         : steps(fp_steps),
-          hysteresis(fp_hysteresis)
+          hysteresis(fp_hysteresis),
+          sensor(fp_sensor)
     {
     }
 };

--- a/radeon-profile/gpu.cpp
+++ b/radeon-profile/gpu.cpp
@@ -139,14 +139,17 @@ void gpu::defineAvailableDataContainer() {
     if (tmpPwm.fanSpeedRpm != -1)
         gpuData.insert(ValueID::FAN_SPEED_RPM, RPValue(ValueUnit::RPM, tmpPwm.fanSpeedRpm));
 
-
-    float tmpTemp = driverHandler->getTemperature();
-
-    if (tmpTemp != -1) {
-        gpuData.insert(ValueID::TEMPERATURE_CURRENT, RPValue(ValueUnit::CELSIUS, tmpTemp));
-        gpuData.insert(ValueID::TEMPERATURE_BEFORE_CURRENT, RPValue(ValueUnit::CELSIUS, tmpTemp));
-        gpuData.insert(ValueID::TEMPERATURE_MIN, RPValue(ValueUnit::CELSIUS, tmpTemp));
-        gpuData.insert(ValueID::TEMPERATURE_MAX, RPValue(ValueUnit::CELSIUS, tmpTemp));
+    const auto &sensors = driverHandler->features.tempSensors;
+    for (int hwmon_id = 0; hwmon_id < sensors.size(); hwmon_id++) {
+        const ValueID::Instance instance = sensors[hwmon_id];
+        const float current = driverHandler->getTemperature(hwmon_id);
+        if (current != -1) {
+            const RPValue rpcurrent(ValueUnit::CELSIUS, current);
+            gpuData.insert(ValueID(ValueID::TEMPERATURE_CURRENT, instance), rpcurrent);
+            gpuData.insert(ValueID(ValueID::TEMPERATURE_BEFORE_CURRENT, instance), rpcurrent);
+            gpuData.insert(ValueID(ValueID::TEMPERATURE_MIN, instance), rpcurrent);
+            gpuData.insert(ValueID(ValueID::TEMPERATURE_MAX, instance), rpcurrent);
+        }
     }
 
     GPUUsage tmpUsage = driverHandler->getGPUUsage();
@@ -200,17 +203,24 @@ void gpu::getClocks() {
 }
 
 void gpu::getTemperature() {
-    if (!gpuData.contains(ValueID::TEMPERATURE_CURRENT))
-        return;
+    const auto &sensors = driverHandler->features.tempSensors;
+    for (int hwmon_id = 0; hwmon_id < sensors.size(); hwmon_id++) {
+       const float current = driverHandler->getTemperature(hwmon_id);
 
-    gpuData[ValueID::TEMPERATURE_BEFORE_CURRENT].setValue(gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
-    gpuData[ValueID::TEMPERATURE_CURRENT].setValue(driverHandler->getTemperature());
+        const ValueID key(ValueID::TEMPERATURE_CURRENT, sensors[hwmon_id]);
+        const ValueID key_before = key.asType(ValueID::TEMPERATURE_BEFORE_CURRENT);
+        gpuData[key_before].setValue(gpuData[key].value);
 
-    if (gpuData.value(ValueID::TEMPERATURE_MIN, RPValue()).value > gpuData.value(ValueID::TEMPERATURE_CURRENT).value)
-        gpuData[ValueID::TEMPERATURE_MIN].setValue(gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
+        gpuData[key].setValue(current);
 
-    if (gpuData.value(ValueID::TEMPERATURE_MAX, RPValue()).value < gpuData.value(ValueID::TEMPERATURE_CURRENT).value)
-        gpuData[ValueID::TEMPERATURE_MAX].setValue(gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
+        const ValueID key_min = key.asType(ValueID::TEMPERATURE_MIN);
+        if (gpuData.value(key_min, RPValue()).value > current)
+            gpuData[key_min].setValue(current);
+
+        const ValueID key_max = key.asType(ValueID::TEMPERATURE_MAX);
+        if (gpuData.value(key_max, RPValue()).value < current)
+            gpuData[key_max].setValue(current);
+    }
 }
 
 void gpu::getGpuUsage() {

--- a/radeon-profile/radeon-profile.pro
+++ b/radeon-profile/radeon-profile.pro
@@ -24,6 +24,7 @@ CONFIG(release, debug|release){
 }
 
 SOURCES += main.cpp\
+    globalStuff.cpp \
     radeon_profile.cpp \
     uiElements.cpp \
     uiEvents.cpp \

--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -460,8 +460,10 @@ void radeon_profile::updateExecLogs() {
                     device.gpuData.value(ValueID::CLK_UVD).strValue + ";"+
                     device.gpuData.value(ValueID::DCLK_UVD).strValue + ";"+
                     device.gpuData.value(ValueID::VOLT_CORE).strValue + ";"+
-                    device.gpuData.value(ValueID::VOLT_MEM).strValue + ";"+
-                    device.gpuData.value(ValueID::TEMPERATURE_CURRENT).strValue;
+                    device.gpuData.value(ValueID::VOLT_MEM).strValue + ";";
+            for (const ValueID::Instance instance : device.getDriverFeatures().tempSensors) {
+                logData += device.gpuData.value(ValueID(ValueID::TEMPERATURE_CURRENT, instance)).strValue;
+            }
             execsRunning.at(i)->appendToLog(logData);
         }
     }

--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -204,7 +204,7 @@ void radeon_profile::setupUiEnabledFeatures(const DriverFeatures &features, cons
 
     ui->tw_systemInfo->setTabEnabled(3,data.contains(ValueID::CLK_CORE));
 
-    if (!device.gpuData.contains(ValueID::CLK_CORE) && !data.contains(ValueID::TEMPERATURE_CURRENT) && !device.gpuData.contains(ValueID::VOLT_CORE))
+    if (!device.gpuData.contains(ValueID::CLK_CORE) && !features.tempSensors.empty() && !device.gpuData.contains(ValueID::VOLT_CORE))
         ui->tw_main->setTabEnabled(1,false);
 
     ui->group_cfgDaemon->setEnabled(dcomm.isConnected());
@@ -359,10 +359,12 @@ void radeon_profile::refreshUI() {
     // GPU data list
     if (ui->tw_main->currentIndex() == 0) {
         for (int i = 0; i < ui->list_currentGPUData->topLevelItemCount(); ++i) {
-            switch (keysInCurrentGpuList.value(i)) {
+            const ValueID key = keysInCurrentGpuList.value(i);
+            switch (key.type) {
                 case ValueID::TEMPERATURE_CURRENT:
-                    ui->list_currentGPUData->topLevelItem(i)->setText(1, createCurrentMinMaxString(ValueID::TEMPERATURE_CURRENT, ValueID::TEMPERATURE_MIN, ValueID::TEMPERATURE_MAX));
+                    ui->list_currentGPUData->topLevelItem(i)->setText(1, createCurrentMinMaxString(key, key.asType(ValueID::TEMPERATURE_MIN), key.asType(ValueID::TEMPERATURE_MAX)));
                     continue;
+
                 case ValueID::POWER_CAP_SELECTED:
                     ui->list_currentGPUData->topLevelItem(i)->setText(1, createCurrentMinMaxString(device.gpuData.value(ValueID::POWER_CAP_SELECTED).strValue,
                                                                                                    QString::number(device.getGpuConstParams().power1_cap_min),
@@ -413,9 +415,8 @@ void radeon_profile::refreshUI() {
 void radeon_profile::createCurrentGpuDataListItems()
 {
     ui->list_currentGPUData->clear();
-    for (int i = 0; i < device.gpuData.keys().count(); ++i) {
-
-        switch (device.gpuData.keys().at(i)) {
+    for (const auto key : device.gpuData.keys()) {
+        switch (key.type) {
 
             // ignored values
             case ValueID::TEMPERATURE_BEFORE_CURRENT:
@@ -424,8 +425,8 @@ void radeon_profile::createCurrentGpuDataListItems()
                 continue;
 
             default:
-                addTreeWidgetItem(ui->list_currentGPUData, globalStuff::getNameOfValueID(device.gpuData.keys().at(i)), "");
-                keysInCurrentGpuList.append(device.gpuData.keys().at(i));
+                addTreeWidgetItem(ui->list_currentGPUData, globalStuff::getNameOfValueID(key), "");
+                keysInCurrentGpuList.append(key);
         }
     }
 }

--- a/radeon-profile/radeon_profile.cpp
+++ b/radeon-profile/radeon_profile.cpp
@@ -522,32 +522,33 @@ void radeon_profile::adjustFanSpeed() {
         return;
 
     if (device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value < device.gpuData.value(ValueID::TEMPERATURE_BEFORE_CURRENT).value &&
-            ui->spin_hysteresis->value() > (hysteresisRelativeTepmerature - device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value))
+            currentFanProfile.hysteresis > (hysteresisRelativeTepmerature - device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value))
         return;
 
     hysteresisRelativeTepmerature = device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value;
 
     // exact match
-    if (currentFanProfile.contains(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value)) {
-        device.setPwmValue(currentFanProfile.value(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value));
+    const auto &steps = currentFanProfile.steps;
+    if (steps.contains(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value)) {
+        device.setPwmValue(steps.value(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value));
         return;
     }
 
     // below first step
-    if (device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value <= currentFanProfile.firstKey()) {
-        device.setPwmValue(currentFanProfile.first());
+    if (device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value <= steps.firstKey()) {
+        device.setPwmValue(steps.first());
         return;
     }
 
     // above last setep
-    if (device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value >= currentFanProfile.lastKey()) {
-        device.setPwmValue(currentFanProfile.last());
+    if (device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value >= steps.lastKey()) {
+        device.setPwmValue(steps.last());
         return;
     }
 
     // find bounds of current temperature
-    auto high = currentFanProfile.upperBound(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
-    auto low = (currentFanProfile.size() > 1 ? high - 1 : high);
+    auto high = steps.upperBound(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
+    auto low = (steps.size() > 1 ? high - 1 : high);
 
     int hSpeed = high.value(),
             lSpeed = low.value();

--- a/radeon-profile/radeon_profile.h
+++ b/radeon-profile/radeon_profile.h
@@ -157,8 +157,8 @@ private:
 
     gpu device;
     QList<ExecBin*> execsRunning;
-    FanProfileSteps currentFanProfile;
-    QMap<QString, FanProfileSteps> fanProfiles;
+    FanProfile currentFanProfile;
+    QMap<QString, FanProfile> fanProfiles;
     QMap<QString, OCProfile> ocProfiles;
     QMap<QString, RPEvent> events;
     QMap<QString, unsigned int> pmStats;
@@ -210,7 +210,7 @@ private:
     void saveExecProfiles(QXmlStreamWriter &xml);
     void loadExecProfile(const QXmlStreamReader &xml);
     void saveFanProfiles(QXmlStreamWriter &xml);
-    void loadFanProfile(QXmlStreamReader &xml);
+    void loadFanProfile(QXmlStreamReader &xml, const int default_hysteresis);
     void savePlotSchemas(QXmlStreamWriter &xml);
     void loadPlotSchemas(QXmlStreamReader &xml);
     void saveTopbarItemsSchemas(QXmlStreamWriter &xml);

--- a/radeon-profile/radeon_profile.h
+++ b/radeon-profile/radeon_profile.h
@@ -173,6 +173,7 @@ private:
     QList<TopbarItem*> topBarItems;
     QList<ValueID> keysInCurrentGpuList;
     QString enabledFrequencyStatesCore, enabledFrequencyStatesMem;
+    CheckInfoStruct eventData;
 
     Ui::radeon_profile *ui;
     void setupTrayIcon();

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -1455,17 +1455,28 @@
               </property>
              </widget>
             </item>
-            <item row="7" column="3">
+            <item row="7" column="2" colspan="2">
+                <widget class="QComboBox" name="combo_fanProfile_sensorInstance">
+                </widget>
+            </item>
+            <item row="7" column="0">
+             <widget class="QLabel" name="label_SensorInstance">
+               <property name="text">
+                 <string>Temperature Sensor</string>
+               </property>
+             </widget>
+            </item>
+            <item row="8" column="3">
              <widget class="QSpinBox" name="spin_hysteresis">
               <property name="maximum">
                <number>5</number>
               </property>
              </widget>
             </item>
-            <item row="0" column="4" rowspan="8">
+            <item row="0" column="4" rowspan="9">
              <layout class="QVBoxLayout" name="verticalLayout_22"/>
             </item>
-            <item row="7" column="0" colspan="3">
+            <item row="8" column="0" colspan="3">
              <widget class="QLabel" name="label_6">
               <property name="text">
                <string>Temperature hysteresis</string>

--- a/radeon-profile/radeon_profile.ui
+++ b/radeon-profile/radeon_profile.ui
@@ -123,7 +123,7 @@
            <number>5</number>
           </property>
           <property name="columnCount">
-           <number>2</number>
+           <number>3</number>
           </property>
           <attribute name="headerVisible">
            <bool>false</bool>
@@ -144,6 +144,11 @@
             <string>Value</string>
            </property>
           </column>
+          <column>
+           <property name="text">
+            <string>Limits</string>
+           </property>
+         </column>
          </widget>
         </item>
         <item row="1" column="0" colspan="2">

--- a/radeon-profile/rpevent.h
+++ b/radeon-profile/rpevent.h
@@ -2,13 +2,14 @@
 #define EVENT_H
 
 #include "globalStuff.h"
+#include <QHash>
 
 enum RPEventType {
     TEMPERATURE, BINARY
 };
 
 struct CheckInfoStruct {
-    unsigned short checkTemperature;
+    QHash<ValueID::Instance, unsigned short> checkTemperature;
 };
 
 class RPEvent {
@@ -19,12 +20,13 @@ public:
     bool enabled;
     QString name, activationBinary, fanProfileNameChange, powerProfileChange, powerLevelChange;
     unsigned short fixedFanSpeedChange, activationTemperature, fanComboIndex;
+    ValueID::Instance sensorInstance = ValueID::T_EDGE; // instance of temp sensor
     RPEventType type;
 
     bool isActivationConditonFulfilled(const CheckInfoStruct &check) {
         switch (type) {
             case RPEventType::TEMPERATURE:
-                return activationTemperature < check.checkTemperature;
+                return activationTemperature < check.checkTemperature[sensorInstance];
             case RPEventType::BINARY:
                 return !globalStuff::grabSystemInfo("pidof \""+activationBinary+"\"")[0].isEmpty();
         }

--- a/radeon-profile/settings.cpp
+++ b/radeon-profile/settings.cpp
@@ -146,6 +146,7 @@ void radeon_profile::saveFanProfiles(QXmlStreamWriter &xml) {
         FanProfile fps = fanProfiles.value(k);
 
         xml.writeAttribute("hysteresis", QString::number(fps.hysteresis));
+        xml.writeAttribute("sensorInstance", QString::number(fps.sensor));
 
         for (auto ks : fps.steps.keys()) {
             xml.writeStartElement("step");
@@ -485,6 +486,9 @@ void radeon_profile::loadFanProfile(QXmlStreamReader &xml, const int default_hys
     fps.hysteresis = xml.attributes().hasAttribute("hysteresis")
                    ? xml.attributes().value("hysteresis").toInt()
                    : default_hysteresis;
+    fps.sensor = xml.attributes().hasAttribute("sensorInstance")
+               ? xml.attributes().value("sensorInstance").toInt()
+               : ValueID::T_EDGE;
     while (xml.readNext()) {
         if (xml.name().toString() == "step" && !xml.attributes().value("temperature").isEmpty())
             fps.steps.insert(xml.attributes().value("temperature").toString().toInt(),

--- a/radeon-profile/settings.cpp
+++ b/radeon-profile/settings.cpp
@@ -207,7 +207,7 @@ void radeon_profile::writePlotAxisSchemaToXml(QXmlStreamWriter &xml, const QStri
     for (const ValueID &sk : pas.dataList.keys()) {
         xml.writeStartElement("serie");
         xml.writeAttribute("align", side);
-        xml.writeAttribute("id", QString::number(sk));
+        xml.writeAttribute("id", QString::number(sk.key()));
         xml.writeAttribute("color", pas.dataList.value(sk).name());
         xml.writeEndElement();
     }
@@ -240,10 +240,10 @@ void radeon_profile::saveTopbarItemsSchemas(QXmlStreamWriter &xml) {
         xml.writeStartElement("topbarItem");
 
         xml.writeAttribute("type", QString::number(tis.type));
-        xml.writeAttribute("primaryValueId", QString::number(tis.primaryValueId));
+        xml.writeAttribute("primaryValueId", QString::number(tis.primaryValueId.key()));
         xml.writeAttribute("primaryColor", tis.primaryColor.name());
         xml.writeAttribute("secondaryValueIdEnabled", QString::number(tis.secondaryValueIdEnabled));
-        xml.writeAttribute("secondaryValueId", QString::number(tis.secondaryValueId));
+        xml.writeAttribute("secondaryValueId", QString::number(tis.secondaryValueId.key()));
         xml.writeAttribute("secondaryColor", tis.secondaryColor.name());
         xml.writeAttribute("pieMaxValue", QString::number(tis.pieMaxValue));
 
@@ -431,9 +431,9 @@ void radeon_profile::loadPlotSchemas(QXmlStreamReader &xml) {
 
         if (xml.name().toString() == "serie") {
             if (xml.attributes().value("align").toString() == "left")
-                pds.left.dataList.insert(static_cast<ValueID>(xml.attributes().value("id").toInt()), QColor(xml.attributes().value("color").toString()));
+                pds.left.dataList.insert(ValueID::fromKey(xml.attributes().value("id").toULong()), QColor(xml.attributes().value("color").toString()));
             else if (xml.attributes().value("align").toString() == "right")
-                pds.right.dataList.insert(static_cast<ValueID>(xml.attributes().value("id").toInt()), QColor(xml.attributes().value("color").toString()));
+                pds.right.dataList.insert(ValueID::fromKey(xml.attributes().value("id").toULong()), QColor(xml.attributes().value("color").toString()));
 
         }
 
@@ -446,7 +446,7 @@ void radeon_profile::loadPlotSchemas(QXmlStreamReader &xml) {
 }
 
 void radeon_profile::loadTopbarItemsSchemas(const QXmlStreamReader &xml) {
-    TopbarItemDefinitionSchema tis(static_cast<ValueID>(xml.attributes().value("primaryValueId").toInt()),
+    TopbarItemDefinitionSchema tis(ValueID::fromKey(xml.attributes().value("primaryValueId").toULong()),
                                    static_cast<TopbarItemType>(xml.attributes().value("type").toInt()),
                                    QColor(xml.attributes().value("primaryColor").toString()));
 
@@ -454,7 +454,7 @@ void radeon_profile::loadTopbarItemsSchemas(const QXmlStreamReader &xml) {
 
     if (xml.attributes().value("secondaryValueIdEnabled").toInt() == 1) {
         tis.setSecondaryColor(QColor(xml.attributes().value("secondaryColor").toString()));
-        tis.setSecondaryValueId(static_cast<ValueID>(xml.attributes().value("secondaryValueId").toInt()));
+        tis.setSecondaryValueId(ValueID::fromKey(xml.attributes().value("secondaryValueId").toULong()));
     }
 
     topbarManager.addSchema(tis);

--- a/radeon-profile/settings.cpp
+++ b/radeon-profile/settings.cpp
@@ -108,6 +108,7 @@ void radeon_profile::saveRpevents(QXmlStreamWriter &xml) {
         xml.writeAttribute("tiggerType", QString::number(rpe.type));
         xml.writeAttribute("activationBinary", rpe.activationBinary);
         xml.writeAttribute("activationTemperature", QString::number(rpe.activationTemperature));
+        xml.writeAttribute("sensorInstance", QString::number(rpe.sensorInstance));
         xml.writeAttribute("powerProfileChange", rpe.powerProfileChange);
         xml.writeAttribute("powerLevelChange", rpe.powerLevelChange);
         xml.writeAttribute("fixedFanSpeedChange", QString::number(rpe.fixedFanSpeedChange));
@@ -389,6 +390,7 @@ void radeon_profile::loadRpevent(const QXmlStreamReader &xml) {
     rpe.type = static_cast<RPEventType>(xml.attributes().value("tiggerType").toInt());
     rpe.activationBinary = xml.attributes().value("activationBinary").toString();
     rpe.activationTemperature = xml.attributes().value("activationTemperature").toInt();
+    rpe.sensorInstance = xml.attributes().value("sensorInstance").toUInt();
     rpe.powerProfileChange = xml.attributes().value("powerProfileChange").toString();
     rpe.powerLevelChange = xml.attributes().value("powerLevelChange").toString();
     rpe.fixedFanSpeedChange = xml.attributes().value("fixedFanSpeedChange").toInt();

--- a/radeon-profile/tab_events.cpp
+++ b/radeon-profile/tab_events.cpp
@@ -27,16 +27,20 @@ void radeon_profile::on_btn_addEvent_clicked()
 }
 
 void radeon_profile::checkEvents() {
-    CheckInfoStruct data;
-    data.checkTemperature = device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value;
+    for (const ValueID::Instance instance : device.getDriverFeatures().tempSensors) {
+        const ValueID id(ValueID::TEMPERATURE_CURRENT, instance);
+        eventData.checkTemperature[instance] = device.gpuData.value(id).value;
+    }
 
     if (savedState != nullptr)  {
         RPEvent e = events.value(ui->l_currentActiveEvent->text());
 
         // one degree handicap to avid constant activation when on the fence
-        data.checkTemperature += 1;
+        for (auto& data : eventData.checkTemperature) {
+            data += 1;
+        }
 
-        if (!e.isActivationConditonFulfilled(data))
+        if (!e.isActivationConditonFulfilled(eventData))
             revokeEvent();
 
         return;
@@ -46,7 +50,7 @@ void radeon_profile::checkEvents() {
         if (!e.enabled)
             continue;
 
-        if (e.isActivationConditonFulfilled(data)) {
+        if (e.isActivationConditonFulfilled(eventData)) {
             activateEvent(e);
             return;
         }

--- a/radeon-profile/tab_exec.cpp
+++ b/radeon-profile/tab_exec.cpp
@@ -285,7 +285,12 @@ void radeon_profile::on_btn_runExecProfile_clicked()
         exe->setLogFilename(item->text(LOG_FILE) +
                             ((item->text(LOG_FILE_DATE_APPEND) == "1") ? QDateTime::currentDateTime().toString("_yyyy-MM-dd_hh-mm-ss") : ""));
         exe->appendToLog("Profile: " +item->text(PROFILE_NAME) +"; App: " + item->text(BINARY) + "; Params: " + item->text(BINARY_PARAMS) + "; Env: " + item->text(ENV_SETTINGS));
-        exe->appendToLog("Date and time; power level; GPU core clk; mem clk; uvd core clk; uvd decoder clk; core voltage (vddc); mem voltage (vddci); temp");
+        QStringList sensors;
+        for (const ValueID::Instance instance : device.getDriverFeatures().tempSensors) {
+            sensors.push_back(globalStuff::getNameOfValueID(ValueID(ValueID::TEMPERATURE_CURRENT, instance)));
+        }
+        exe->appendToLog("Date and time; power level; GPU core clk; mem clk; uvd core clk; uvd decoder clk; core voltage (vddc); mem voltage (vddci);" + sensors.join("; "));
+
     }
 
     execsRunning.append(exe);

--- a/radeon-profile/tab_fanControl.cpp
+++ b/radeon-profile/tab_fanControl.cpp
@@ -21,14 +21,16 @@ void radeon_profile::createFanProfileListaAndGraph(const QString &profileName) {
     series->clear();
     ui->list_fanSteps->clear();
 
-    series->append(0, profile.first());
+    series->append(0, profile.steps.first());
 
-    for (int temperature : profile.keys()) {
-        series->append(temperature, profile.value(temperature));
-        ui->list_fanSteps->addTopLevelItem(new QTreeWidgetItem(QStringList() << QString::number(temperature) << QString::number(profile.value(temperature))));
+    for (int temperature : profile.steps.keys()) {
+        series->append(temperature, profile.steps.value(temperature));
+        ui->list_fanSteps->addTopLevelItem(new QTreeWidgetItem(QStringList() << QString::number(temperature) << QString::number(profile.steps.value(temperature))));
     }
 
-    series->append(100, profile.last());
+    series->append(100, profile.steps.last());
+
+    ui->spin_hysteresis->setValue(profile.hysteresis);
 }
 
 void radeon_profile::makeFanProfilePlot() {
@@ -95,8 +97,9 @@ void radeon_profile::on_btn_removeFanProfile_clicked()
 void radeon_profile::on_btn_saveFanProfile_clicked()
 {
     markFanProfileUnsaved(false);
-    const auto fanProfile = stepsListToMap();
+    const FanProfile fanProfile(stepsListToMap(), ui->spin_hysteresis->value());
     fanProfiles.insert(ui->combo_fanProfiles->currentText(), fanProfile);
+
     saveConfig();
 
     if (ui->combo_fanProfiles->currentText() == ui->l_currentFanProfile->text())
@@ -116,8 +119,8 @@ void radeon_profile::on_btn_saveAsFanProfile_clicked()
     }
 
     markFanProfileUnsaved(false);
-
-    fanProfiles.insert(name, stepsListToMap());
+    const FanProfile fanProfile(stepsListToMap(), ui->spin_hysteresis->value());
+    fanProfiles.insert(name, fanProfile);
     ui->combo_fanProfiles->addItem(name);
     ui->combo_fanProfiles->setCurrentText(name);
     createFanProfilesMenu(true);
@@ -242,7 +245,7 @@ void radeon_profile::on_btn_removeFanStep_clicked()
     QTreeWidgetItem *current = ui->list_fanSteps->takeTopLevelItem(ui->list_fanSteps->currentIndex().row());
 
     // The selected item can be removed, remove it
-    currentFanProfile.remove(current->text(0).toInt());
+    currentFanProfile.steps.remove(current->text(0).toInt());
     adjustFanSpeed();
 
     // Remove the step from the list and from the graph

--- a/radeon-profile/tab_fanControl.cpp
+++ b/radeon-profile/tab_fanControl.cpp
@@ -31,6 +31,12 @@ void radeon_profile::createFanProfileListaAndGraph(const QString &profileName) {
     series->append(100, profile.steps.last());
 
     ui->spin_hysteresis->setValue(profile.hysteresis);
+
+    auto index = ui->combo_fanProfile_sensorInstance->findData(profile.sensor);
+    if (index == -1)
+        index = ui->combo_fanProfile_sensorInstance->findData(
+            device.getDriverFeatures().tempSensors.first());
+    ui->combo_fanProfile_sensorInstance->setCurrentIndex(index);
 }
 
 void radeon_profile::makeFanProfilePlot() {
@@ -97,7 +103,9 @@ void radeon_profile::on_btn_removeFanProfile_clicked()
 void radeon_profile::on_btn_saveFanProfile_clicked()
 {
     markFanProfileUnsaved(false);
-    const FanProfile fanProfile(stepsListToMap(), ui->spin_hysteresis->value());
+    const FanProfile fanProfile(stepsListToMap(),
+        ui->spin_hysteresis->value(),
+        ui->combo_fanProfile_sensorInstance->currentData().value<ValueID::Instance>());
     fanProfiles.insert(ui->combo_fanProfiles->currentText(), fanProfile);
 
     saveConfig();
@@ -119,7 +127,9 @@ void radeon_profile::on_btn_saveAsFanProfile_clicked()
     }
 
     markFanProfileUnsaved(false);
-    const FanProfile fanProfile(stepsListToMap(), ui->spin_hysteresis->value());
+    const FanProfile fanProfile(stepsListToMap(),
+        ui->spin_hysteresis->value(),
+        ui->combo_fanProfile_sensorInstance->currentData().value<ValueID::Instance>());
     fanProfiles.insert(name, fanProfile);
     ui->combo_fanProfiles->addItem(name);
     ui->combo_fanProfiles->setCurrentText(name);

--- a/radeon-profile/uiEvents.cpp
+++ b/radeon-profile/uiEvents.cpp
@@ -24,8 +24,11 @@ void radeon_profile::setPowerLevelFromCombo() {
 }
 
 void radeon_profile::resetMinMax() {
-    device.gpuData[ValueID::TEMPERATURE_MIN].setValue(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
-    device.gpuData[ValueID::TEMPERATURE_MAX].setValue(device.gpuData.value(ValueID::TEMPERATURE_CURRENT).value);
+    for (const ValueID::Instance instance : device.getDriverFeatures().tempSensors) {
+        const auto current = device.gpuData.value(ValueID(ValueID::TEMPERATURE_CURRENT, instance)).value;
+        device.gpuData[ValueID(ValueID::TEMPERATURE_MIN, instance)].setValue(current);
+        device.gpuData[ValueID(ValueID::TEMPERATURE_MAX, instance)].setValue(current);
+    }
 }
 
 void radeon_profile::setPowerProfile(int mode) {


### PR DESCRIPTION
Newer radeon graphics cards since vega20 – including AFAIK all navi based cards – expose three temperature sensors via the hwmon: Edge temperature (the "classic" GPU temp), junction temperature and memory temperature. radeon-profile so far only read the first temperature sensor (edge temp). 

This set of changes enables detecting all available temperature sensors when hwmon is available. Including any other sensors not listed above - should there ever be any. This data is then made available to the user throughout the UI in the following places:

- display current temperature in the GPU data list
- also display critical and emergency temperature limits in GPU data list
- all sensors can be selected to display temperature in topbar widgets
- all sensors can be selected to display in charts in the Graphs tab
- the temperature sensor to use for fan curves can be selected when creating fan curves in the fan control -> custom curves tab. Different fan profiles can use different temperature sensors.
- all sensors readings can be used to generate events in the events tab
- Exec logs include all temperature readings

(On top of that, I also changed the hysteresis setting in the fan control tab to a per profile setting rather than a global one, since that seemed more consistent).

Any card not supporting more than one temperature sensor should still work as it had before. It was so far only tested on a Radeon VII (vega20) though.

For easier review, each of those features is split into its own commit. The most intrusive change is the replacement of the ValueID enum with a struct containing two components in the first commit: the type enum, and a new instance id. This allows to use multiple values of the same ValueID type with each their own unique key in gpu::gpuData. I considered just adding more values to the ValueID enum for junction/mem temperature and their min/max/before values respectively, but this would not allow dynamically creating an arbitrary number of sensors. It would also require to blow up a lot of switch statements with a lot of new cases for each new sensor. Using a key with two components seemed more flexible for future use to me.




